### PR TITLE
Add enum validation support

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -55,6 +55,13 @@ module Ucfg # rubocop:todo Style/Documentation
           errors << "Property `#{(config_path + [key]).join('.')}` contains an unsupported value (provided `#{value}`)"
         end
       end
+
+      if schema["properties"].key?(key) && schema["properties"][key].key?("const")
+        unless schema["properties"][key]["const"] == value
+          valid = false
+          errors << "Property `#{(config_path + [key]).join('.')}` must have value `#{schema['properties'][key]['const']}` (provided `#{value}`)"
+        end
+      end
     end
 
     schema["properties"].each do |key, value|

--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -44,9 +44,9 @@ module Ucfg # rubocop:todo Style/Documentation
     config.each do |key, value|
       if schema["properties"].key?(key) && schema["properties"][key].key?("type")
         if schema["properties"][key]["type"].is_a?(String) && schema["properties"][key]["type"] == value_type(value)
-          next
+          # All good, just continue
         elsif schema["properties"][key]["type"].is_a?(Array) && schema["properties"][key]["type"].include?(value_type(value))
-          next
+          # All good, just continue
         else
           valid = false
           errors << "Property `#{(config_path + [key]).join('.')}` must be of type #{type_to_sentence(schema['properties'][key]['type'])} (#{value_type_error(value)})"

--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -48,6 +48,13 @@ module Ucfg # rubocop:todo Style/Documentation
           errors << "Property `#{(config_path + [key]).join('.')}` must be of type `#{schema['properties'][key]['type']}` (provided value `#{value}` of type `#{value_type(value)}`)"
         end
       end
+
+      if schema["properties"].key?(key) && schema["properties"][key].key?("enum") && schema["properties"][key]["enum"].is_a?(Array)
+        unless schema["properties"][key]["enum"].include?(value)
+          valid = false
+          errors << "Property `#{(config_path + [key]).join('.')}` contains an unsupported value (provided `#{value}`)"
+        end
+      end
     end
 
     schema["properties"].each do |key, value|

--- a/spec/enum_validation_spec.rb
+++ b/spec/enum_validation_spec.rb
@@ -37,4 +37,21 @@ RSpec.describe "Enum validation" do
     expect(Ucfg.validate({ "name" => true }, schema_as_hash)).to be_valid
     expect(Ucfg.validate({ "name" => "false" }, schema_as_hash).errors).to eq(["Property `name` contains an unsupported value (provided `false`)"])
   end
+
+  it "supports const" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "color": {
+          "type": "string",
+          "const": "red"
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "color" => "red" }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "color" => "yellow" }, schema_as_hash).errors).to eq(["Property `color` must have value `red` (provided `yellow`)"])
+  end
 end

--- a/spec/enum_validation_spec.rb
+++ b/spec/enum_validation_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "json"
+
+RSpec.describe "Enum validation" do
+  it "supports string enum check" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "color": {
+          "type": "string",
+          "enum": ["red", "green", "blue"]
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "color" => "red" }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "color" => "blue" }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "color" => "yellow" }, schema_as_hash).errors).to eq(["Property `color` contains an unsupported value (provided `yellow`)"])
+  end
+
+  it "supports mixed value enum check" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "name": {
+          "enum": ["true", true]
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "name" => "true" }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "name" => true }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "name" => "false" }, schema_as_hash).errors).to eq(["Property `name` contains an unsupported value (provided `false`)"])
+  end
+end


### PR DESCRIPTION
This PR adds support for the `enum` validation - this is a neat way to validation against a specific set of allowed values.