### PR TITLE
Add restricted YAML validation support

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -3,9 +3,14 @@
 require "ucfg/version"
 require "ucfg/json_schema"
 require "ucfg/validation_result"
+require "ucfg/yaml_loader"
 
 module Ucfg
   class Error < StandardError; end
+
+  def self.validate_yaml(source, schema)
+    validate(YAMLLoader.load(source), schema)
+  end
 
   def self.validate(config, schema)
     result = JSONSchema.validate_recursively(config, schema, path: [])

--- a/lib/ucfg/yaml_loader.rb
+++ b/lib/ucfg/yaml_loader.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "psych"
+
+module Ucfg
+  module YAMLLoader
+    class << self
+      def load(source)
+        yaml = normalize_source(source)
+
+        stream = Psych.parse_stream(yaml)
+        raise Error, "YAML document is empty" if stream.children.empty?
+        raise Error, "Multi-document YAML is not supported" if stream.children.length > 1
+
+        document = stream.children.first
+        raise Error, "YAML document must contain a single root value" unless document&.children&.length == 1
+
+        convert_node(document.children.first, path: [])
+      rescue Psych::SyntaxError => e
+        raise Error, "Invalid YAML syntax at line #{e.line}, column #{e.column}: #{e.problem}"
+      end
+
+      private
+
+      def normalize_source(source)
+        return source.to_str if source.respond_to?(:to_str)
+
+        raise Error, "YAML source must be a string"
+      end
+
+      def convert_node(node, path:)
+        reject_anchor!(node)
+        reject_tag!(node)
+
+        case node
+        when Psych::Nodes::Mapping
+          convert_mapping(node, path: path)
+        when Psych::Nodes::Sequence
+          convert_sequence(node, path: path)
+        when Psych::Nodes::Scalar
+          convert_scalar(node)
+        when Psych::Nodes::Alias
+          raise_error_at(node, "Aliases and anchors are not supported")
+        else
+          raise_error_at(node, "Unsupported YAML node #{node.class.name}")
+        end
+      end
+
+      def convert_mapping(node, path:)
+        raise_error_at(node, "Flow style mappings are not supported") if node.style == Psych::Nodes::Mapping::FLOW
+
+        children = node.children
+        raise_error_at(node, "Invalid mapping") if children.length.odd?
+
+        children.each_slice(2).each_with_object({}) do |(key_node, value_node), result|
+          key = convert_key(key_node)
+          insert_mapping_value!(result, key, value_node, path: path)
+        end
+      end
+
+      def convert_sequence(node, path:)
+        raise_error_at(node, "Flow style sequences are not supported") if node.style == Psych::Nodes::Sequence::FLOW
+
+        node.children.each_with_index.map do |child, index|
+          convert_node(child, path: path + [index.to_s])
+        end
+      end
+
+      def convert_key(node)
+        unless node.is_a?(Psych::Nodes::Scalar)
+          raise_error_at(node, "Only string object keys are supported")
+        end
+
+        reject_anchor!(node)
+        reject_tag!(node)
+
+        if [Psych::Nodes::Scalar::LITERAL, Psych::Nodes::Scalar::FOLDED].include?(node.style)
+          raise_error_at(node, "Block scalars are not supported")
+        end
+
+        raise_error_at(node, "Merge keys are not supported") if node.value == "<<"
+
+        node.value
+      end
+
+      def convert_scalar(node)
+        if [Psych::Nodes::Scalar::LITERAL, Psych::Nodes::Scalar::FOLDED].include?(node.style)
+          raise_error_at(node, "Block scalars are not supported")
+        end
+
+        return node.value if quoted_scalar?(node)
+        return nil if node.value == ""
+
+        case node.value
+        when "true"
+          true
+        when "false"
+          false
+        when "null"
+          nil
+        else
+          parse_number(node.value) || node.value
+        end
+      end
+
+      def quoted_scalar?(node)
+        [Psych::Nodes::Scalar::SINGLE_QUOTED, Psych::Nodes::Scalar::DOUBLE_QUOTED].include?(node.style)
+      end
+
+      def parse_number(value)
+        return Integer(value, 10) if value.match?(/\A-?(?:0|[1-9][0-9]*)\z/)
+        return Float(value) if value.match?(/\A-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)\z/)
+        return Float(value) if value.match?(/\A-?(?:0|[1-9][0-9]*)\.[0-9]+\z/)
+
+        nil
+      end
+
+      def insert_mapping_value!(result, raw_key, value_node, path:)
+        segments = raw_key.split(".")
+        raise Error, "Invalid dotted key `#{raw_key}`" if segments.any?(&:empty?)
+
+        current = result
+
+        segments[0...-1].each_with_index do |segment, index|
+          existing = current[segment]
+          joined_path = (path + segments[0..index]).join(".")
+
+          if existing.nil?
+            current[segment] = {}
+          elsif !existing.is_a?(Hash)
+            raise Error, "Key `#{joined_path}` cannot be both a scalar and an object"
+          end
+
+          current = current[segment]
+        end
+
+        leaf = segments.last
+        full_path = (path + segments).join(".")
+        value = convert_node(value_node, path: path + segments)
+
+        if current.key?(leaf)
+          existing = current[leaf]
+
+          if existing.is_a?(Hash) != value.is_a?(Hash)
+            raise Error, "Key `#{full_path}` cannot be both a scalar and an object"
+          end
+
+          raise Error, "Duplicate key `#{full_path}`"
+        end
+
+        current[leaf] = value
+      end
+
+      def reject_anchor!(node)
+        return unless node.respond_to?(:anchor) && node.anchor
+
+        raise_error_at(node, "Aliases and anchors are not supported")
+      end
+
+      def reject_tag!(node)
+        return unless node.respond_to?(:tag) && node.tag
+
+        raise_error_at(node, "Explicit tags are not supported")
+      end
+
+      def raise_error_at(node, message)
+        line = node.respond_to?(:start_line) ? node.start_line + 1 : nil
+        column = node.respond_to?(:start_column) ? node.start_column + 1 : nil
+
+        if line && column
+          raise Error, "#{message} at line #{line}, column #{column}"
+        end
+
+        raise Error, message
+      end
+    end
+  end
+end

--- a/lib/ucfg/yaml_loader.rb
+++ b/lib/ucfg/yaml_loader.rb
@@ -122,12 +122,11 @@ module Ucfg
         current = result
 
         segments[0...-1].each_with_index do |segment, index|
-          existing = current[segment]
           joined_path = (path + segments[0..index]).join(".")
 
-          if existing.nil?
+          if !current.key?(segment)
             current[segment] = {}
-          elsif !existing.is_a?(Hash)
+          elsif !current[segment].is_a?(Hash)
             raise Error, "Key `#{joined_path}` cannot be both a scalar and an object"
           end
 

--- a/spec/validate_yaml_spec.rb
+++ b/spec/validate_yaml_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Ucfg do
+  describe ".validate_yaml" do
+    it "loads yaml and validates it" do
+      yaml = <<~YAML
+        service.name: ucfg
+        service.enabled: true
+      YAML
+
+      schema = {
+        "properties" => {
+          "service" => {
+            "required" => ["name", "enabled"],
+            "properties" => {
+              "name" => { "type" => "string" },
+              "enabled" => { "type" => "boolean" },
+            },
+          },
+        },
+      }
+
+      result = described_class.validate_yaml(yaml, schema)
+
+      expect(result).to be_valid
+      expect(result.errors).to eq([])
+    end
+
+    it "surfaces validation errors after loading yaml" do
+      yaml = <<~YAML
+        service.name: ucfg
+        service.enabled: nope
+      YAML
+
+      schema = {
+        "properties" => {
+          "service" => {
+            "required" => ["name", "enabled"],
+            "properties" => {
+              "name" => { "type" => "string" },
+              "enabled" => { "type" => "boolean" },
+            },
+          },
+        },
+      }
+
+      result = described_class.validate_yaml(yaml, schema)
+
+      expect(result.valid?).to eq(false)
+      expect(result.errors).to eq(["Property `service.enabled` must be of type `boolean` (provided value `nope` of type `string`)"])
+    end
+
+    it "surfaces yaml parsing errors" do
+      yaml = <<~YAML
+        items: [one, two]
+      YAML
+
+      expect { described_class.validate_yaml(yaml, {}) }.to raise_error(Ucfg::Error, /flow style/i)
+    end
+  end
+end

--- a/spec/yaml_loader_spec.rb
+++ b/spec/yaml_loader_spec.rb
@@ -159,6 +159,15 @@ RSpec.describe Ucfg::YAMLLoader do
       expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /scalar.*object|object.*scalar/i)
     end
 
+    it "raises when an omitted null value is later expanded with dot notation" do
+      yaml = <<~YAML
+        server:
+        server.port: 5432
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /scalar.*object|object.*scalar/i)
+    end
+
     it "raises for unsupported flow style collections" do
       yaml = <<~YAML
         items: [one, two]

--- a/spec/yaml_loader_spec.rb
+++ b/spec/yaml_loader_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+RSpec.describe Ucfg::YAMLLoader do
+  describe ".load" do
+    it "supports a top-level array root" do
+      yaml = <<~YAML
+        - app
+        - 42
+        - true
+      YAML
+
+      expect(described_class.load(yaml)).to eq(["app", 42, true])
+    end
+
+    it "supports top-level scalar roots" do
+      expect(described_class.load("hello\n")).to eq("hello")
+      expect(described_class.load("42\n")).to eq(42)
+      expect(described_class.load("false\n")).to eq(false)
+      expect(described_class.load("null\n")).to eq(nil)
+    end
+
+    it "parses supported scalars without YAML implicit boolean surprises" do
+      yaml = <<~YAML
+        mode: production
+        on_value: on
+        off_value: off
+        yes_value: yes
+        no_value: no
+        enabled: true
+        disabled: false
+        missing: null
+        count: 42
+        price: 12.5
+        ratio: 1e6
+        message: "hello world"
+      YAML
+
+      expect(described_class.load(yaml)).to eq(
+        {
+          "mode" => "production",
+          "on_value" => "on",
+          "off_value" => "off",
+          "yes_value" => "yes",
+          "no_value" => "no",
+          "enabled" => true,
+          "disabled" => false,
+          "missing" => nil,
+          "count" => 42,
+          "price" => 12.5,
+          "ratio" => 1_000_000.0,
+          "message" => "hello world",
+        },
+      )
+    end
+
+    it "treats non-canonical numeric-looking values as strings" do
+      yaml = <<~YAML
+        leading_zero: 01
+        explicit_plus: +1
+        leading_decimal: .5
+        canonical_negative_float: -0.5
+        exponent_float: 1.0e6
+      YAML
+
+      expect(described_class.load(yaml)).to eq(
+        {
+          "leading_zero" => "01",
+          "explicit_plus" => "+1",
+          "leading_decimal" => ".5",
+          "canonical_negative_float" => -0.5,
+          "exponent_float" => 1_000_000.0,
+        },
+      )
+    end
+
+    it "parses nested objects and arrays" do
+      yaml = <<~YAML
+        server:
+          host: localhost
+          ports:
+            - 443
+            - 8443
+        environments:
+          - name: production
+            enabled: true
+          - name: staging
+            enabled: false
+      YAML
+
+      expect(described_class.load(yaml)).to eq(
+        {
+          "server" => {
+            "host" => "localhost",
+            "ports" => [443, 8443],
+          },
+          "environments" => [
+            { "name" => "production", "enabled" => true },
+            { "name" => "staging", "enabled" => false },
+          ],
+        },
+      )
+    end
+
+    it "treats omitted values as null" do
+      yaml = <<~YAML
+        server:
+          host: localhost
+          port:
+        feature.enabled:
+      YAML
+
+      expect(described_class.load(yaml)).to eq(
+        {
+          "server" => {
+            "host" => "localhost",
+            "port" => nil,
+          },
+          "feature" => {
+            "enabled" => nil,
+          },
+        },
+      )
+    end
+
+    it "supports dot notation alongside indentation-based nesting" do
+      yaml = <<~YAML
+        server:
+          host: localhost
+        database.port: 5432
+        database.enabled: true
+      YAML
+
+      expect(described_class.load(yaml)).to eq(
+        {
+          "server" => { "host" => "localhost" },
+          "database" => {
+            "port" => 5432,
+            "enabled" => true,
+          },
+        },
+      )
+    end
+
+    it "raises for duplicate keys" do
+      yaml = <<~YAML
+        name: app
+        name: other
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /duplicate key/i)
+    end
+
+    it "raises when a path is both a scalar and an object" do
+      yaml = <<~YAML
+        server: localhost
+        server.port: 5432
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /scalar.*object|object.*scalar/i)
+    end
+
+    it "raises for unsupported flow style collections" do
+      yaml = <<~YAML
+        items: [one, two]
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /flow style/i)
+    end
+
+    it "raises for unsupported aliases" do
+      yaml = <<~YAML
+        defaults: &defaults
+          host: localhost
+        server: *defaults
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /alias|anchor/i)
+    end
+
+    it "raises for unsupported merge keys" do
+      yaml = <<~YAML
+        server:
+          <<:
+            host: localhost
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /merge key/i)
+    end
+
+    it "raises for unsupported explicit tags" do
+      yaml = <<~YAML
+        value: !custom tagged
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /explicit tag/i)
+    end
+
+    it "raises for unsupported block scalars" do
+      yaml = <<~YAML
+        message: |
+          hello
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /block scalar/i)
+    end
+
+    it "raises for tabs in indentation" do
+      yaml = "server:\n\tport: 5432\n"
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /invalid yaml syntax/i)
+    end
+
+    it "raises for malformed indentation" do
+      yaml = <<~YAML
+        server:
+          host: localhost
+           port: 5432
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /invalid yaml syntax/i)
+    end
+
+    it "raises for an empty yaml document" do
+      expect { described_class.load("") }.to raise_error(Ucfg::Error, /document is empty/i)
+      expect { described_class.load("   \n") }.to raise_error(Ucfg::Error, /document is empty/i)
+    end
+
+    it "raises for a comment-only yaml document" do
+      yaml = <<~YAML
+        # comment
+        # another comment
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /document is empty/i)
+    end
+
+    it "raises for multi-document input" do
+      yaml = <<~YAML
+        first: true
+        ---
+        second: false
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /multi-document/i)
+    end
+  end
+end


### PR DESCRIPTION
This adds a restricted YAML input path so configs can be written in YAML while still being validated through the existing JSON-schema-based API. The goal is to support a predictable subset of YAML without inheriting YAML's broader implicit typing and feature surface.

The change introduces an internal Psych-backed `YAMLLoader` that parses only the supported structures and scalars, rejects unsupported YAML features such as flow style, aliases, merge keys, explicit tags, block scalars, and multi-document input, and expands dotted keys into nested hashes with duplicate/conflict detection. On top of that, `Ucfg.validate_yaml(source, schema)` was added as the public API so callers can validate YAML directly without managing a separate parse step.

The new specs cover the internal loader contract and the public `validate_yaml` API separately. They document root scalar and array handling, scalar coercion rules, omitted values mapping to `nil`, dot notation behavior, parse errors for unsupported YAML, and end-to-end validation behavior.

Tests: `bundle exec rspec`