### PR TITLE
Add internal raw config file loader

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -3,6 +3,7 @@
 require "ucfg/version"
 require "ucfg/json_schema"
 require "ucfg/validation_result"
+require "ucfg/file_loader"
 require "ucfg/yaml_loader"
 
 module Ucfg

--- a/lib/ucfg/file_loader.rb
+++ b/lib/ucfg/file_loader.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Ucfg
+  module FileLoader
+    class << self
+      def read(path)
+        normalized_path = normalize_path(path)
+        File.read(normalized_path)
+      rescue SystemCallError => e
+        raise Error, "Failed to read file `#{normalized_path}`: #{e.message}"
+      end
+
+      private
+
+      def normalize_path(path)
+        return path.to_path if path.respond_to?(:to_path)
+        return path.to_str if path.respond_to?(:to_str)
+
+        raise Error, "File path must be a string or path-like object"
+      end
+    end
+  end
+end

--- a/spec/file_loader_spec.rb
+++ b/spec/file_loader_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "tmpdir"
+
+RSpec.describe Ucfg::FileLoader do
+  describe ".read" do
+    it "reads content from a readable file" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.yml")
+        File.write(path, "name: app\n")
+
+        expect(described_class.read(path)).to eq("name: app\n")
+      end
+    end
+
+    it "returns an empty string for an empty file" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "empty.yml")
+        File.write(path, "")
+
+        expect(described_class.read(path)).to eq("")
+      end
+    end
+
+    it "raises Ucfg::Error when the file is missing" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "missing.yml")
+
+        expect { described_class.read(path) }
+          .to raise_error(Ucfg::Error, /Failed to read file `#{Regexp.escape(path)}`: No such file or directory/i)
+      end
+    end
+
+    it "raises Ucfg::Error when the file is unreadable" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "private.yml")
+        File.write(path, "secret: true\n")
+        File.chmod(0o000, path)
+
+        if File.readable?(path)
+          skip("unable to make file unreadable in this environment")
+        end
+
+        expect { described_class.read(path) }
+          .to raise_error(Ucfg::Error, /Failed to read file `#{Regexp.escape(path)}`: Permission denied/i)
+      ensure
+        File.chmod(0o644, path) if File.exist?(path)
+      end
+    end
+
+    it "accepts path-like objects" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.yml")
+        File.write(path, "enabled: true\n")
+
+        expect(described_class.read(Pathname.new(path))).to eq("enabled: true\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why
The library needed a narrow, reusable component for loading configuration content from disk before any YAML parsing or template handling. This keeps file I/O concerns isolated and makes loader behavior explicit for missing and unreadable files.

## What changed
- Added `Ucfg::FileLoader.read(path)` to read file content as a raw string.
- Accepted string and path-like inputs via `to_path`/`to_str`.
- Wrapped filesystem read failures in `Ucfg::Error` with a consistent message format.
- Wired the new loader into the gem requires.
- Added specs for readable file, empty file, missing file, unreadable file (with env-safe skip when permissions cannot be enforced), and path-like input.

## Notes for reviewers
- The loader intentionally does not parse YAML, render ERB, merge configs, or validate schemas.
- Empty files return `""` (not `nil`).
- Error messages are explicit and include the normalized path and original system error text.