### PR TITLE
Add opt-in ERB template renderer for config text

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -4,6 +4,7 @@ require "ucfg/version"
 require "ucfg/json_schema"
 require "ucfg/validation_result"
 require "ucfg/file_loader"
+require "ucfg/template_renderer"
 require "ucfg/yaml_loader"
 
 module Ucfg

--- a/lib/ucfg/template_renderer.rb
+++ b/lib/ucfg/template_renderer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "erb"
+
+module Ucfg
+  module TemplateRenderer
+    class << self
+      def render(source, erb: false)
+        template = normalize_source(source)
+        return template unless erb
+
+        ERB.new(template).result
+      rescue SyntaxError => e
+        raise Error, "Invalid ERB syntax: #{e.message.lines.first&.strip || e.message}"
+      end
+
+      private
+
+      def normalize_source(source)
+        return source.to_str if source.respond_to?(:to_str)
+
+        raise Error, "Template source must be a string"
+      end
+    end
+  end
+end

--- a/spec/template_renderer_spec.rb
+++ b/spec/template_renderer_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Ucfg::TemplateRenderer do
+  describe ".render" do
+    it "returns the original source when ERB rendering is disabled" do
+      source = "api_key: <%= ENV['API_KEY'] %>"
+
+      expect(described_class.render(source, erb: false)).to eq(source)
+    end
+
+    it "interpolates ENV values when ERB rendering is enabled" do
+      with_env("API_KEY", "secret-token") do
+        rendered = described_class.render("api_key: <%= ENV['API_KEY'] %>", erb: true)
+
+        expect(rendered).to eq("api_key: secret-token")
+      end
+    end
+
+    it "supports default-value logic in ERB expressions" do
+      with_env("MISSING", nil) do
+        rendered = described_class.render("value: <%= ENV['MISSING'] || 'default' %>", erb: true)
+
+        expect(rendered).to eq("value: default")
+      end
+    end
+
+    it "raises Ucfg::Error for invalid ERB syntax" do
+      source = "value: <%= ENV['API_KEY']"
+
+      expect { described_class.render(source, erb: true) }
+        .to raise_error(Ucfg::Error, /invalid erb syntax/i)
+    end
+
+    it "raises Ucfg::Error for non-string input" do
+      expect { described_class.render(123, erb: false) }
+        .to raise_error(Ucfg::Error, /template source must be a string/i)
+      expect { described_class.render(123, erb: true) }
+        .to raise_error(Ucfg::Error, /template source must be a string/i)
+    end
+  end
+
+  def with_env(key, value)
+    original = ENV[key]
+
+    if value.nil?
+      ENV.delete(key)
+    else
+      ENV[key] = value
+    end
+
+    yield
+  ensure
+    if original.nil?
+      ENV.delete(key)
+    else
+      ENV[key] = original
+    end
+  end
+end

--- a/spec/template_renderer_spec.rb
+++ b/spec/template_renderer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Ucfg::TemplateRenderer do
     end
 
     it "raises Ucfg::Error for invalid ERB syntax" do
-      source = "value: <%= ENV['API_KEY']"
+      source = "value: <%= ENV['API_KEY' %>"
 
       expect { described_class.render(source, erb: true) }
         .to raise_error(Ucfg::Error, /invalid erb syntax/i)


### PR DESCRIPTION
Configuration text sometimes needs runtime interpolation (for example ENV lookups) before any YAML handling, but ERB execution must remain explicit and isolated.

This change adds a focused `Ucfg::TemplateRenderer` component with `render(source, erb: false)`. It returns the original string by default, and only evaluates standard Ruby ERB when `erb: true`, so expressions like `ENV[...]` and fallback logic work as expected. Invalid ERB syntax is converted into `Ucfg::Error` with a clear message, and non-string input raises `Ucfg::Error` as well.

## Tests
- disabled rendering returns the input unchanged
- ENV interpolation with ERB enabled
- default-value logic via `ENV['MISSING'] || 'default'`
- invalid ERB syntax raises `Ucfg::Error`
- non-string input raises `Ucfg::Error`

## Security note
ERB rendering executes Ruby code. It should only be enabled for trusted configuration input.