### PR TITLE
Harden YAML dotted-key parsing and mixed-key normalization

### DIFF
--- a/lib/ucfg/yaml_loader.rb
+++ b/lib/ucfg/yaml_loader.rb
@@ -144,10 +144,39 @@ module Ucfg
             raise Error, "Key `#{full_path}` cannot be both a scalar and an object"
           end
 
+          if existing.is_a?(Hash)
+            merge_mapping_values!(existing, value, path: path + segments)
+            return
+          end
+
           raise Error, "Duplicate key `#{full_path}`"
         end
 
         current[leaf] = value
+      end
+
+      def merge_mapping_values!(target, incoming, path:)
+        incoming.each do |key, incoming_value|
+          full_path = (path + [key]).join(".")
+
+          unless target.key?(key)
+            target[key] = incoming_value
+            next
+          end
+
+          target_value = target[key]
+
+          if target_value.is_a?(Hash) && incoming_value.is_a?(Hash)
+            merge_mapping_values!(target_value, incoming_value, path: path + [key])
+            next
+          end
+
+          if target_value.is_a?(Hash) != incoming_value.is_a?(Hash)
+            raise Error, "Key `#{full_path}` cannot be both a scalar and an object"
+          end
+
+          raise Error, "Duplicate key `#{full_path}`"
+        end
       end
 
       def reject_anchor!(node)

--- a/spec/yaml_loader_spec.rb
+++ b/spec/yaml_loader_spec.rb
@@ -141,6 +141,46 @@ RSpec.describe Ucfg::YAMLLoader do
       )
     end
 
+    it "normalizes mixed flat and nested keys regardless of order" do
+      yaml = <<~YAML
+        service.name: ucfg
+        service:
+          enabled: true
+      YAML
+
+      expect(described_class.load(yaml)).to eq(
+        {
+          "service" => {
+            "name" => "ucfg",
+            "enabled" => true,
+          },
+        },
+      )
+    end
+
+    it "supports arrays containing nested objects with dotted keys" do
+      yaml = <<~YAML
+        items:
+          - name: app
+            limits.cpu: 2
+            limits.memory: 512
+      YAML
+
+      expect(described_class.load(yaml)).to eq(
+        {
+          "items" => [
+            {
+              "name" => "app",
+              "limits" => {
+                "cpu" => 2,
+                "memory" => 512,
+              },
+            },
+          ],
+        },
+      )
+    end
+
     it "raises for duplicate keys" do
       yaml = <<~YAML
         name: app
@@ -148,6 +188,16 @@ RSpec.describe Ucfg::YAMLLoader do
       YAML
 
       expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /duplicate key/i)
+    end
+
+    it "raises for duplicate dotted keys in mixed flat and nested mappings" do
+      yaml = <<~YAML
+        service.name: app
+        service:
+          name: other
+      YAML
+
+      expect { described_class.load(yaml) }.to raise_error(Ucfg::Error, /duplicate key `service.name`/i)
     end
 
     it "raises when a path is both a scalar and an object" do


### PR DESCRIPTION
## Why
The YAML loader was order-dependent when the same object path was expressed as both dotted keys and nested mappings. A valid config like `service.name: ...` followed by `service:` incorrectly raised a duplicate-key error.

## What changed
- Updated dotted-key insertion to recursively merge mapping-vs-mapping values at the same path.
- Kept strict behavior for real duplicates and scalar-vs-object conflicts.
- Added focused YAML loader specs for:
  - mixed flat/nested key normalization in reverse order,
  - arrays containing nested objects with dotted keys,
  - duplicate dotted-key detection across mixed flat/nested mappings.

## Notes for reviewers
This is parser-only scope. File loading, ERB rendering, merge behavior, schema validation, and unsupported YAML feature handling remain unchanged.