### PR TITLE
Add oneOf/anyOf/allOf JSON Schema validation

### DIFF
--- a/lib/ucfg/json_schema.rb
+++ b/lib/ucfg/json_schema.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require "ucfg/json_schema/additional_properties"
+require "ucfg/json_schema/all_of"
+require "ucfg/json_schema/any_of"
 require "ucfg/json_schema/const"
 require "ucfg/json_schema/enum"
 require "ucfg/json_schema/items"
 require "ucfg/json_schema/min_max"
 require "ucfg/json_schema/max"
 require "ucfg/json_schema/min"
+require "ucfg/json_schema/one_of"
 require "ucfg/json_schema/properties"
 require "ucfg/json_schema/required"
 require "ucfg/json_schema/type"
@@ -18,12 +21,15 @@ module Ucfg
       def validate_recursively(instance, schema, path:)
         [
           JSONSchema::AdditionalProperties,
+          JSONSchema::AllOf,
+          JSONSchema::AnyOf,
           JSONSchema::Const,
           JSONSchema::Enum,
           JSONSchema::Items,
           JSONSchema::Max,
           JSONSchema::Min,
           JSONSchema::MinMax,
+          JSONSchema::OneOf,
           JSONSchema::Required,
           JSONSchema::Type,
           JSONSchema::Properties,

--- a/lib/ucfg/json_schema/all_of.rb
+++ b/lib/ucfg/json_schema/all_of.rb
@@ -11,6 +11,8 @@ module Ucfg
           return unless schema["allOf"].is_a?(Array)
 
           schema["allOf"].reduce(JSONSchema.empty_result) do |memo, subschema|
+            next memo unless subschema.is_a?(Hash)
+
             result = JSONSchema.validate_recursively(instance, subschema, path: path)
             JSONSchema.combine_results(memo, result)
           end

--- a/lib/ucfg/json_schema/all_of.rb
+++ b/lib/ucfg/json_schema/all_of.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class AllOf
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("allOf")
+          return unless schema["allOf"].is_a?(Array)
+
+          schema["allOf"].reduce(JSONSchema.empty_result) do |memo, subschema|
+            result = JSONSchema.validate_recursively(instance, subschema, path: path)
+            JSONSchema.combine_results(memo, result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/any_of.rb
+++ b/lib/ucfg/json_schema/any_of.rb
@@ -19,6 +19,8 @@ module Ucfg
 
         def matching_subschema_count(instance, subschemas, path:)
           subschemas.count do |subschema|
+            next false unless subschema.is_a?(Hash)
+
             result = JSONSchema.validate_recursively(instance, subschema, path: path)
             result.fetch(:validation_errors).empty?
           end

--- a/lib/ucfg/json_schema/any_of.rb
+++ b/lib/ucfg/json_schema/any_of.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class AnyOf
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("anyOf")
+          return unless schema["anyOf"].is_a?(Array)
+
+          return if matching_subschema_count(instance, schema["anyOf"], path: path) > 0
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must match at least one schema in `anyOf`")
+        end
+
+        private
+
+        def matching_subschema_count(instance, subschemas, path:)
+          subschemas.count do |subschema|
+            result = JSONSchema.validate_recursively(instance, subschema, path: path)
+            result.fetch(:validation_errors).empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/one_of.rb
+++ b/lib/ucfg/json_schema/one_of.rb
@@ -20,6 +20,8 @@ module Ucfg
 
         def matching_subschema_count(instance, subschemas, path:)
           subschemas.count do |subschema|
+            next false unless subschema.is_a?(Hash)
+
             result = JSONSchema.validate_recursively(instance, subschema, path: path)
             result.fetch(:validation_errors).empty?
           end

--- a/lib/ucfg/json_schema/one_of.rb
+++ b/lib/ucfg/json_schema/one_of.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class OneOf
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("oneOf")
+          return unless schema["oneOf"].is_a?(Array)
+
+          matching_subschemas = matching_subschema_count(instance, schema["oneOf"], path: path)
+          return if matching_subschemas == 1
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must match exactly one schema in `oneOf` (matched #{matching_subschemas})")
+        end
+
+        private
+
+        def matching_subschema_count(instance, subschemas, path:)
+          subschemas.count do |subschema|
+            result = JSONSchema.validate_recursively(instance, subschema, path: path)
+            result.fetch(:validation_errors).empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/json_schema/composition_spec.rb
+++ b/spec/json_schema/composition_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe "JSON Schema composition keywords" do
       expect(result.valid?).to eq(false)
       expect(result.errors).to eq(["Property `value` must match at least one schema in `anyOf`"])
     end
+
+    it "ignores non-object subschemas" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "anyOf" => [
+              nil,
+              "invalid",
+              { "type" => "string" },
+            ],
+          },
+        },
+      }
+
+      expect(Ucfg.validate({ "value" => "text" }, schema)).to be_valid
+    end
   end
 
   describe "oneOf" do
@@ -95,6 +111,22 @@ RSpec.describe "JSON Schema composition keywords" do
       expect(result.valid?).to eq(false)
       expect(result.errors).to eq(["Property `value` must match exactly one schema in `oneOf` (matched 2)"])
     end
+
+    it "ignores non-object subschemas" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "oneOf" => [
+              nil,
+              123,
+              { "type" => "number" },
+            ],
+          },
+        },
+      }
+
+      expect(Ucfg.validate({ "value" => 7 }, schema)).to be_valid
+    end
   end
 
   describe "allOf" do
@@ -133,6 +165,23 @@ RSpec.describe "JSON Schema composition keywords" do
 
       expect(result.valid?).to eq(false)
       expect(result.errors).to eq(["Property `value` must be greater than or equal to 3 (provided 2)"])
+    end
+
+    it "ignores non-object subschemas" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "allOf" => [
+              nil,
+              "invalid",
+              { "type" => "number" },
+              { "min" => 1 },
+            ],
+          },
+        },
+      }
+
+      expect(Ucfg.validate({ "value" => 2 }, schema)).to be_valid
     end
   end
 

--- a/spec/json_schema/composition_spec.rb
+++ b/spec/json_schema/composition_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "json"
+
+RSpec.describe "JSON Schema composition keywords" do
+  describe "anyOf" do
+    it "passes when at least one subschema matches" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "anyOf" => [
+              { "type" => "string" },
+              { "type" => "number" },
+            ],
+          },
+        },
+      }
+
+      result = Ucfg.validate({ "value" => "text" }, schema)
+
+      expect(result).to be_valid
+      expect(result.errors).to eq([])
+    end
+
+    it "fails when no subschema matches" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "anyOf" => [
+              { "type" => "string" },
+              { "type" => "number" },
+            ],
+          },
+        },
+      }
+
+      result = Ucfg.validate({ "value" => true }, schema)
+
+      expect(result.valid?).to eq(false)
+      expect(result.errors).to eq(["Property `value` must match at least one schema in `anyOf`"])
+    end
+  end
+
+  describe "oneOf" do
+    it "passes when exactly one subschema matches" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "oneOf" => [
+              { "type" => "string" },
+              { "type" => "number" },
+            ],
+          },
+        },
+      }
+
+      result = Ucfg.validate({ "value" => 7 }, schema)
+
+      expect(result).to be_valid
+      expect(result.errors).to eq([])
+    end
+
+    it "fails when no subschema matches" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "oneOf" => [
+              { "type" => "string" },
+              { "type" => "number" },
+            ],
+          },
+        },
+      }
+
+      result = Ucfg.validate({ "value" => nil }, schema)
+
+      expect(result.valid?).to eq(false)
+      expect(result.errors).to eq(["Property `value` must match exactly one schema in `oneOf` (matched 0)"])
+    end
+
+    it "fails when more than one subschema matches" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "oneOf" => [
+              { "type" => "number" },
+              { "min" => 0 },
+            ],
+          },
+        },
+      }
+
+      result = Ucfg.validate({ "value" => 5 }, schema)
+
+      expect(result.valid?).to eq(false)
+      expect(result.errors).to eq(["Property `value` must match exactly one schema in `oneOf` (matched 2)"])
+    end
+  end
+
+  describe "allOf" do
+    it "passes when all subschemas match" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "allOf" => [
+              { "type" => "number" },
+              { "min" => 3 },
+              { "max" => 8 },
+            ],
+          },
+        },
+      }
+
+      result = Ucfg.validate({ "value" => 5 }, schema)
+
+      expect(result).to be_valid
+      expect(result.errors).to eq([])
+    end
+
+    it "fails when any subschema fails" do
+      schema = {
+        "properties" => {
+          "value" => {
+            "allOf" => [
+              { "type" => "number" },
+              { "min" => 3 },
+            ],
+          },
+        },
+      }
+
+      result = Ucfg.validate({ "value" => 2 }, schema)
+
+      expect(result.valid?).to eq(false)
+      expect(result.errors).to eq(["Property `value` must be greater than or equal to 3 (provided 2)"])
+    end
+  end
+
+  it "includes nested property paths in composition errors" do
+    schema = {
+      "properties" => {
+        "parent" => {
+          "properties" => {
+            "child" => {
+              "anyOf" => [
+                { "type" => "string" },
+                { "type" => "number" },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    result = Ucfg.validate({ "parent" => { "child" => true } }, schema)
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(["Property `parent.child` must match at least one schema in `anyOf`"])
+  end
+
+  it "includes array item paths in composition errors" do
+    schema = {
+      "properties" => {
+        "values" => {
+          "type" => "array",
+          "items" => {
+            "oneOf" => [
+              { "type" => "number" },
+              { "type" => "string" },
+            ],
+          },
+        },
+      },
+    }
+
+    result = Ucfg.validate({ "values" => [1, true] }, schema)
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(["Property `values.1` must match exactly one schema in `oneOf` (matched 0)"])
+  end
+end


### PR DESCRIPTION
## Why
The validator currently handles basic JSON Schema keywords but not composition keywords. This blocks schemas that express alternatives or combined constraints via `oneOf`, `anyOf`, and `allOf`.

## What changed
- Added dedicated validators for `oneOf`, `anyOf`, and `allOf`.
- Wired these validators into the existing `JSONSchema.validate_recursively` validator chain.
- Kept the existing validation result shape intact (`validation_errors` array) and reused the current recursive validation flow.
- Added focused specs for each keyword covering pass/fail semantics:
  - `oneOf`: exactly one subschema must match
  - `anyOf`: at least one subschema must match
  - `allOf`: every subschema must match
- Added coverage for error path behavior on nested object properties and array item paths.

## Notes
- Scope is intentionally limited to composition keywords only; no unrelated JSON Schema keywords or loading APIs were changed.
- Composition failure messages include the current property path, consistent with existing error formatting.