### PR TITLE
Add patternProperties and align additionalProperties coverage

### DIFF
--- a/lib/ucfg/json_schema.rb
+++ b/lib/ucfg/json_schema.rb
@@ -55,6 +55,19 @@ module Ucfg
       def result_with_validation_error(message)
         { validation_errors: [message] }
       end
+
+      def compile_pattern_properties(pattern_properties, path:)
+        pattern_properties.reduce([[], empty_result]) do |(compiled_patterns, errors), (pattern, sub_schema)|
+          begin
+            compiled_patterns << [Regexp.new(pattern), sub_schema]
+          rescue RegexpError, TypeError
+            result = result_with_validation_error("Pattern `#{(path + [pattern.to_s]).join('.')}` is not a valid regular expression")
+            errors = combine_results(errors, result)
+          end
+
+          [compiled_patterns, errors]
+        end
+      end
     end
   end
 end

--- a/lib/ucfg/json_schema.rb
+++ b/lib/ucfg/json_schema.rb
@@ -10,6 +10,7 @@ require "ucfg/json_schema/min_max"
 require "ucfg/json_schema/max"
 require "ucfg/json_schema/min"
 require "ucfg/json_schema/one_of"
+require "ucfg/json_schema/pattern_properties"
 require "ucfg/json_schema/properties"
 require "ucfg/json_schema/required"
 require "ucfg/json_schema/type"
@@ -30,6 +31,7 @@ module Ucfg
           JSONSchema::Min,
           JSONSchema::MinMax,
           JSONSchema::OneOf,
+          JSONSchema::PatternProperties,
           JSONSchema::Required,
           JSONSchema::Type,
           JSONSchema::Properties,

--- a/lib/ucfg/json_schema/additional_properties.rb
+++ b/lib/ucfg/json_schema/additional_properties.rb
@@ -12,12 +12,13 @@ module Ucfg
 
           explicit_properties = schema["properties"].is_a?(Hash) ? schema["properties"] : {}
           pattern_properties = schema["patternProperties"].is_a?(Hash) ? schema["patternProperties"] : {}
-          compiled_patterns = pattern_properties.map { |pattern, _| Regexp.new(pattern) }
+          compiled_patterns, _ = JSONSchema.compile_pattern_properties(pattern_properties, path: path + ["patternProperties"])
+          key_matches_pattern = ->(key) { compiled_patterns.any? { |regex, _| regex.match?(key.to_s) } }
 
           if schema["additionalProperties"] == false
             instance.reduce(JSONSchema.empty_result) do |memo, (key, _)|
               next memo if explicit_properties.key?(key)
-              next memo if compiled_patterns.any? { |regex| regex.match?(key.to_s) }
+              next memo if key_matches_pattern.call(key)
 
               result = JSONSchema.result_with_validation_error("Property `#{(path + [key]).join('.')}` is not supported")
               JSONSchema.combine_results(memo, result)
@@ -25,7 +26,7 @@ module Ucfg
           elsif schema["additionalProperties"].is_a?(Hash)
             instance.reduce(JSONSchema.empty_result) do |memo, (key, _)|
               next memo if explicit_properties.key?(key)
-              next memo if compiled_patterns.any? { |regex| regex.match?(key.to_s) }
+              next memo if key_matches_pattern.call(key)
 
               result = JSONSchema.validate_recursively(instance.fetch(key), schema["additionalProperties"], path: path + [key])
               JSONSchema.combine_results(memo, result)

--- a/lib/ucfg/json_schema/additional_properties.rb
+++ b/lib/ucfg/json_schema/additional_properties.rb
@@ -10,20 +10,24 @@ module Ucfg
           return unless schema.key?("additionalProperties")
           return unless instance.is_a?(Hash)
 
-          if schema["additionalProperties"] == false
-            return unless schema.key?("properties")
-            return unless schema["properties"].is_a?(Hash)
+          explicit_properties = schema["properties"].is_a?(Hash) ? schema["properties"] : {}
+          pattern_properties = schema["patternProperties"].is_a?(Hash) ? schema["patternProperties"] : {}
+          compiled_patterns = pattern_properties.map { |pattern, _| Regexp.new(pattern) }
 
+          if schema["additionalProperties"] == false
             instance.reduce(JSONSchema.empty_result) do |memo, (key, _)|
-              result = JSONSchema.result_with_validation_error("Property `#{(path + [key]).join('.')}` is not supported") unless schema["properties"].key?(key)
+              next memo if explicit_properties.key?(key)
+              next memo if compiled_patterns.any? { |regex| regex.match?(key.to_s) }
+
+              result = JSONSchema.result_with_validation_error("Property `#{(path + [key]).join('.')}` is not supported")
               JSONSchema.combine_results(memo, result)
             end
           elsif schema["additionalProperties"].is_a?(Hash)
             instance.reduce(JSONSchema.empty_result) do |memo, (key, _)|
-              result =
-                if schema.key?("properties") && schema["properties"].is_a?(Hash) && !schema["properties"].key?(key) || !schema.key?("properties")
-                  JSONSchema.validate_recursively(instance.fetch(key), schema["additionalProperties"], path: path + [key])
-                end
+              next memo if explicit_properties.key?(key)
+              next memo if compiled_patterns.any? { |regex| regex.match?(key.to_s) }
+
+              result = JSONSchema.validate_recursively(instance.fetch(key), schema["additionalProperties"], path: path + [key])
               JSONSchema.combine_results(memo, result)
             end
           end

--- a/lib/ucfg/json_schema/pattern_properties.rb
+++ b/lib/ucfg/json_schema/pattern_properties.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class PatternProperties
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("patternProperties")
+          return unless schema["patternProperties"].is_a?(Hash)
+          return unless instance.is_a?(Hash)
+
+          compiled_patterns = schema["patternProperties"].map { |pattern, sub_schema| [Regexp.new(pattern), sub_schema] }
+
+          instance.reduce(JSONSchema.empty_result) do |memo, (key, value)|
+            key_result = compiled_patterns.reduce(JSONSchema.empty_result) do |key_memo, (regex, sub_schema)|
+              next key_memo unless regex.match?(key.to_s)
+
+              result = JSONSchema.validate_recursively(value, sub_schema, path: path + [key])
+              JSONSchema.combine_results(key_memo, result)
+            end
+            JSONSchema.combine_results(memo, key_result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/pattern_properties.rb
+++ b/lib/ucfg/json_schema/pattern_properties.rb
@@ -11,9 +11,9 @@ module Ucfg
           return unless schema["patternProperties"].is_a?(Hash)
           return unless instance.is_a?(Hash)
 
-          compiled_patterns = schema["patternProperties"].map { |pattern, sub_schema| [Regexp.new(pattern), sub_schema] }
+          compiled_patterns, errors = JSONSchema.compile_pattern_properties(schema["patternProperties"], path: path + ["patternProperties"])
 
-          instance.reduce(JSONSchema.empty_result) do |memo, (key, value)|
+          result = instance.reduce(JSONSchema.empty_result) do |memo, (key, value)|
             key_result = compiled_patterns.reduce(JSONSchema.empty_result) do |key_memo, (regex, sub_schema)|
               next key_memo unless regex.match?(key.to_s)
 
@@ -22,6 +22,8 @@ module Ucfg
             end
             JSONSchema.combine_results(memo, key_result)
           end
+
+          JSONSchema.combine_results(errors, result)
         end
       end
     end

--- a/spec/json_schema/pattern_properties_spec.rb
+++ b/spec/json_schema/pattern_properties_spec.rb
@@ -124,4 +124,56 @@ RSpec.describe "patternProperties" do
     expect(result.valid?).to eq(false)
     expect(result.errors).to eq(["Property `other` must be of type `number` (provided value `nope` of type `string`)"])
   end
+
+  it "returns a validation error for invalid patternProperties regex" do
+    config = <<-JSON
+    {
+      "x-timeout": 30
+    }
+    JSON
+
+    schema = <<-JSON
+    {
+      "patternProperties": {
+        "[": {
+          "type": "number"
+        }
+      }
+    }
+    JSON
+
+    result = Ucfg.validate(JSON.parse(config), JSON.parse(schema))
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(["Pattern `patternProperties.[` is not a valid regular expression"])
+  end
+
+  it "does not crash additionalProperties matching when pattern regex is invalid" do
+    config = <<-JSON
+    {
+      "other": "nope"
+    }
+    JSON
+
+    schema = <<-JSON
+    {
+      "additionalProperties": false,
+      "patternProperties": {
+        "[": {
+          "type": "number"
+        }
+      }
+    }
+    JSON
+
+    result = Ucfg.validate(JSON.parse(config), JSON.parse(schema))
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(
+      [
+        "Property `other` is not supported",
+        "Pattern `patternProperties.[` is not a valid regular expression",
+      ],
+    )
+  end
 end

--- a/spec/json_schema/pattern_properties_spec.rb
+++ b/spec/json_schema/pattern_properties_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "json"
+
+RSpec.describe "patternProperties" do
+  it "still validates explicit properties" do
+    config = <<-JSON
+    {
+      "name": true,
+      "x-timeout": 30
+    }
+    JSON
+
+    schema = <<-JSON
+    {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "type": "number"
+        }
+      }
+    }
+    JSON
+
+    result = Ucfg.validate(JSON.parse(config), JSON.parse(schema))
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(["Property `name` must be of type `string` (provided value `true` of type `boolean`)"])
+  end
+
+  it "validates keys matched by patternProperties" do
+    config = <<-JSON
+    {
+      "service": {
+        "x-timeout": "slow"
+      }
+    }
+    JSON
+
+    schema = <<-JSON
+    {
+      "properties": {
+        "service": {
+          "patternProperties": {
+            "^x-": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+    JSON
+
+    result = Ucfg.validate(JSON.parse(config), JSON.parse(schema))
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(["Property `service.x-timeout` must be of type `number` (provided value `slow` of type `string`)"])
+  end
+
+  it "rejects extra properties when additionalProperties is false, except covered keys" do
+    config = <<-JSON
+    {
+      "name": "ucfg",
+      "x-timeout": 30,
+      "other": "nope"
+    }
+    JSON
+
+    schema = <<-JSON
+    {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "type": "number"
+        }
+      }
+    }
+    JSON
+
+    result = Ucfg.validate(JSON.parse(config), JSON.parse(schema))
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(["Property `other` is not supported"])
+  end
+
+  it "applies additionalProperties schema only to uncovered keys" do
+    config = <<-JSON
+    {
+      "name": "ucfg",
+      "x-enabled": true,
+      "other": "nope"
+    }
+    JSON
+
+    schema = <<-JSON
+    {
+      "additionalProperties": {
+        "type": "number"
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "type": "boolean"
+        }
+      }
+    }
+    JSON
+
+    result = Ucfg.validate(JSON.parse(config), JSON.parse(schema))
+
+    expect(result.valid?).to eq(false)
+    expect(result.errors).to eq(["Property `other` must be of type `number` (provided value `nope` of type `string`)"])
+  end
+end


### PR DESCRIPTION
## Why
Object validation needed support for dynamic keys in JSON Schema. This adds `patternProperties` and ensures `additionalProperties` handles key coverage correctly when explicit and regex-matched keys are present.

## What changed
- Added a new `PatternProperties` validator and wired it into the JSON Schema validator pipeline.
- Implemented `patternProperties` behavior so object properties with names matching configured regex patterns are validated against their schemas.
- Updated `additionalProperties` handling to treat keys covered by either `properties` or `patternProperties` as non-additional.
- Updated `additionalProperties` schema behavior to validate only keys not covered by `properties` or `patternProperties`.
- Added focused specs for:
  - explicit property validation,
  - pattern-matched property validation,
  - rejected extra properties with `additionalProperties: false`,
  - `additionalProperties` schema validation for uncovered keys.

## Notes
- Error reporting continues to include full property paths, including nested paths for pattern-matched keys.
- Scope is intentionally limited to object-key behavior; no changes were made to `oneOf`/`anyOf`/`allOf`, string/array keywords, loading/rendering/parsing paths, or documentation.