### PR TITLE
Add practical string/array JSON Schema keywords

### DIFF
--- a/lib/ucfg/json_schema.rb
+++ b/lib/ucfg/json_schema.rb
@@ -4,12 +4,18 @@ require "ucfg/json_schema/additional_properties"
 require "ucfg/json_schema/const"
 require "ucfg/json_schema/enum"
 require "ucfg/json_schema/items"
+require "ucfg/json_schema/max_items"
+require "ucfg/json_schema/max_length"
 require "ucfg/json_schema/min_max"
+require "ucfg/json_schema/min_items"
+require "ucfg/json_schema/min_length"
 require "ucfg/json_schema/max"
 require "ucfg/json_schema/min"
+require "ucfg/json_schema/pattern"
 require "ucfg/json_schema/properties"
 require "ucfg/json_schema/required"
 require "ucfg/json_schema/type"
+require "ucfg/json_schema/unique_items"
 require "ucfg/validation_result"
 
 module Ucfg
@@ -22,10 +28,16 @@ module Ucfg
           JSONSchema::Enum,
           JSONSchema::Items,
           JSONSchema::Max,
+          JSONSchema::MaxItems,
+          JSONSchema::MaxLength,
           JSONSchema::Min,
           JSONSchema::MinMax,
+          JSONSchema::MinItems,
+          JSONSchema::MinLength,
+          JSONSchema::Pattern,
           JSONSchema::Required,
           JSONSchema::Type,
+          JSONSchema::UniqueItems,
           JSONSchema::Properties,
         ].reduce(empty_result) do |memo, validator|
           result = validator.validate(instance, schema, path: path)

--- a/lib/ucfg/json_schema/max_items.rb
+++ b/lib/ucfg/json_schema/max_items.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class MaxItems
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("maxItems")
+          return unless instance.is_a?(Array)
+          return unless schema["maxItems"].is_a?(Integer) && schema["maxItems"] >= 0
+
+          return if instance.length <= schema["maxItems"]
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must contain at most #{schema['maxItems']} items (provided #{instance.length})")
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/max_length.rb
+++ b/lib/ucfg/json_schema/max_length.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class MaxLength
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("maxLength")
+          return unless instance.is_a?(String)
+          return unless schema["maxLength"].is_a?(Integer) && schema["maxLength"] >= 0
+
+          return if instance.length <= schema["maxLength"]
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must have at most #{schema['maxLength']} characters (provided length #{instance.length})")
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/min_items.rb
+++ b/lib/ucfg/json_schema/min_items.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class MinItems
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("minItems")
+          return unless instance.is_a?(Array)
+          return unless schema["minItems"].is_a?(Integer) && schema["minItems"] >= 0
+
+          return if instance.length >= schema["minItems"]
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must contain at least #{schema['minItems']} items (provided #{instance.length})")
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/min_length.rb
+++ b/lib/ucfg/json_schema/min_length.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class MinLength
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("minLength")
+          return unless instance.is_a?(String)
+          return unless schema["minLength"].is_a?(Integer) && schema["minLength"] >= 0
+
+          return if instance.length >= schema["minLength"]
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must have at least #{schema['minLength']} characters (provided length #{instance.length})")
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/pattern.rb
+++ b/lib/ucfg/json_schema/pattern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class Pattern
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema.key?("pattern")
+          return unless instance.is_a?(String)
+          return unless schema["pattern"].is_a?(String)
+
+          return if instance.match?(Regexp.new(schema["pattern"]))
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must match pattern `#{schema['pattern']}` (provided `#{instance}`)")
+        end
+      end
+    end
+  end
+end

--- a/lib/ucfg/json_schema/pattern.rb
+++ b/lib/ucfg/json_schema/pattern.rb
@@ -11,9 +11,12 @@ module Ucfg
           return unless instance.is_a?(String)
           return unless schema["pattern"].is_a?(String)
 
-          return if instance.match?(Regexp.new(schema["pattern"]))
+          regexp = Regexp.new(schema["pattern"])
+          return if instance.match?(regexp)
 
           JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must match pattern `#{schema['pattern']}` (provided `#{instance}`)")
+        rescue RegexpError => e
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` has invalid pattern `#{schema['pattern']}` in schema (#{e.message})")
         end
       end
     end

--- a/lib/ucfg/json_schema/unique_items.rb
+++ b/lib/ucfg/json_schema/unique_items.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "ucfg/json_schema"
+
+module Ucfg
+  module JSONSchema
+    class UniqueItems
+      class << self
+        def validate(instance, schema, path:)
+          return unless schema["uniqueItems"] == true
+          return unless instance.is_a?(Array)
+          return if instance.length == instance.uniq.length
+
+          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must contain unique items")
+        end
+      end
+    end
+  end
+end

--- a/spec/string_array_validation_spec.rb
+++ b/spec/string_array_validation_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "json"
+
+RSpec.describe "String and array validation" do
+  it "supports minLength, maxLength and pattern for strings" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 5,
+          "pattern": "^[a-z]+$"
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "name" => "abc" }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "name" => "abcdef" }, schema_as_hash).errors).to eq(["Property `name` must have at most 5 characters (provided length 6)"])
+    expect(Ucfg.validate({ "name" => "ab" }, schema_as_hash).errors).to eq(["Property `name` must have at least 3 characters (provided length 2)"])
+    expect(Ucfg.validate({ "name" => "abc1" }, schema_as_hash).errors).to eq(["Property `name` must match pattern `^[a-z]+$` (provided `abc1`)"])
+  end
+
+  it "ignores string keywords for non-string values" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "name": {
+          "type": "number",
+          "minLength": 3,
+          "maxLength": 5,
+          "pattern": "^[a-z]+$"
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "name" => 12 }, schema_as_hash)).to be_valid
+  end
+
+  it "supports minItems, maxItems and uniqueItems for arrays" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "tags": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 3,
+          "uniqueItems": true
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "tags" => ["a", "b"] }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "tags" => ["a"] }, schema_as_hash).errors).to eq(["Property `tags` must contain at least 2 items (provided 1)"])
+    expect(Ucfg.validate({ "tags" => ["a", "b", "c", "d"] }, schema_as_hash).errors).to eq(["Property `tags` must contain at most 3 items (provided 4)"])
+    expect(Ucfg.validate({ "tags" => ["a", "a"] }, schema_as_hash).errors).to eq(["Property `tags` must contain unique items"])
+  end
+
+  it "ignores array keywords for non-array values" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "tags": {
+          "type": "string",
+          "minItems": 2,
+          "maxItems": 3,
+          "uniqueItems": true
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "tags" => "abc" }, schema_as_hash)).to be_valid
+  end
+
+  it "includes nested property path and array index path in errors" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "service": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 4
+            },
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3
+              }
+            }
+          }
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "service" => { "name" => "api", "aliases" => ["main", "x"] } }, schema_as_hash).errors).to eq([
+      "Property `service.name` must have at least 4 characters (provided length 3)",
+      "Property `service.aliases.1` must have at least 3 characters (provided length 1)",
+    ])
+  end
+end

--- a/spec/string_array_validation_spec.rb
+++ b/spec/string_array_validation_spec.rb
@@ -110,4 +110,20 @@ RSpec.describe "String and array validation" do
       "Property `service.aliases.1` must have at least 3 characters (provided length 1)",
     ])
   end
+
+  it "fails gracefully for invalid pattern definitions in schema" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "["
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "name" => "abc" }, schema_as_hash).errors).to match([a_string_starting_with("Property `name` has invalid pattern `[` in schema (")])
+  end
 end


### PR DESCRIPTION
## Why
Config validation needed practical constraints for string and array values beyond type checks so common schema rules can be enforced directly.

## What changed
- Added validators for `minLength`, `maxLength`, and `pattern` for string instances.
- Added validators for `minItems`, `maxItems`, and `uniqueItems` for array instances.
- Wired all six validators into the JSON Schema validation pipeline while preserving the existing `ValidationResult` shape.
- Added focused specs for valid/invalid string and array cases, ignored non-applicable keywords, nested property paths, and array index paths.

## Notes
- Keyword checks are ignored when the instance type does not match, consistent with existing validator behavior.
- `pattern` uses Ruby regexp semantics (`Regexp`) rather than full JSON Schema ECMA-262 regex semantics.