### PR TITLE
Add public YAML/file loading API methods

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -10,8 +10,23 @@ require "ucfg/yaml_loader"
 module Ucfg
   class Error < StandardError; end
 
+  def self.load_yaml(source, erb: false)
+    rendered = TemplateRenderer.render(source, erb: erb)
+    YAMLLoader.load(rendered)
+  end
+
+  def self.load_file(path, erb: false)
+    source = FileLoader.read(path)
+    load_yaml(source, erb: erb)
+  end
+
+  def self.validate_file(path, schema, erb: false)
+    config = load_file(path, erb: erb)
+    validate(config, schema)
+  end
+
   def self.validate_yaml(source, schema)
-    validate(YAMLLoader.load(source), schema)
+    validate(load_yaml(source), schema)
   end
 
   def self.validate(config, schema)

--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -11,7 +11,9 @@ module Ucfg
   class Error < StandardError; end
 
   def self.load_yaml(source, erb: false)
-    rendered = TemplateRenderer.render(source, erb: erb)
+    return YAMLLoader.load(source) unless erb
+
+    rendered = TemplateRenderer.render(source, erb: true)
     YAMLLoader.load(rendered)
   end
 

--- a/spec/public_loading_api_spec.rb
+++ b/spec/public_loading_api_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe Ucfg do
+  describe ".load_yaml" do
+    it "parses YAML without ERB rendering by default" do
+      source = <<~YAML
+        api_key: <%= ENV["PUBLIC_LOADING_API_KEY"] %>
+      YAML
+
+      expect(described_class.load_yaml(source)).to eq(
+        "api_key" => '<%= ENV["PUBLIC_LOADING_API_KEY"] %>',
+      )
+    end
+
+    it "renders ERB before parsing when erb is enabled" do
+      with_env("PUBLIC_LOADING_API_KEY", "secret-token") do
+        source = <<~YAML
+          api_key: <%= ENV["PUBLIC_LOADING_API_KEY"] %>
+        YAML
+
+        expect(described_class.load_yaml(source, erb: true)).to eq(
+          "api_key" => "secret-token",
+        )
+      end
+    end
+  end
+
+  describe ".load_file" do
+    it "loads file content without ERB rendering by default" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.yml")
+        File.write(path, "api_key: <%= ENV[\"PUBLIC_LOADING_API_FILE_KEY\"] %>\n")
+
+        expect(described_class.load_file(path)).to eq(
+          "api_key" => '<%= ENV["PUBLIC_LOADING_API_FILE_KEY"] %>',
+        )
+      end
+    end
+
+    it "renders ERB in file content when erb is enabled" do
+      with_env("PUBLIC_LOADING_API_FILE_KEY", "file-secret") do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "config.yml")
+          File.write(path, "api_key: <%= ENV[\"PUBLIC_LOADING_API_FILE_KEY\"] %>\n")
+
+          expect(described_class.load_file(path, erb: true)).to eq(
+            "api_key" => "file-secret",
+          )
+        end
+      end
+    end
+  end
+
+  describe ".validate_file" do
+    it "loads and validates file content" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.yml")
+        File.write(path, "service.enabled: true\n")
+
+        schema = {
+          "properties" => {
+            "service" => {
+              "required" => ["enabled"],
+              "properties" => {
+                "enabled" => { "type" => "boolean" },
+              },
+            },
+          },
+        }
+
+        result = described_class.validate_file(path, schema)
+
+        expect(result).to be_valid
+        expect(result.errors).to eq([])
+      end
+    end
+  end
+
+  describe ".validate_yaml" do
+    it "remains compatible with callers that do not pass options" do
+      source = <<~YAML
+        service.name: ucfg
+      YAML
+
+      schema = {
+        "properties" => {
+          "service" => {
+            "required" => ["name"],
+            "properties" => {
+              "name" => { "type" => "string" },
+            },
+          },
+        },
+      }
+
+      result = described_class.validate_yaml(source, schema)
+
+      expect(result).to be_valid
+      expect(result.errors).to eq([])
+    end
+  end
+
+  def with_env(key, value)
+    original = ENV[key]
+    ENV[key] = value
+    yield
+  ensure
+    if original.nil?
+      ENV.delete(key)
+    else
+      ENV[key] = original
+    end
+  end
+end

--- a/spec/public_loading_api_spec.rb
+++ b/spec/public_loading_api_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Ucfg do
         )
       end
     end
+
+    it "keeps YAMLLoader non-string error behavior when ERB is disabled" do
+      expect { described_class.load_yaml(123) }
+        .to raise_error(Ucfg::Error, /YAML source must be a string/i)
+    end
   end
 
   describe ".load_file" do
@@ -99,6 +104,11 @@ RSpec.describe Ucfg do
 
       expect(result).to be_valid
       expect(result.errors).to eq([])
+    end
+
+    it "keeps non-string source errors compatible" do
+      expect { described_class.validate_yaml(123, {}) }
+        .to raise_error(Ucfg::Error, /YAML source must be a string/i)
     end
   end
 


### PR DESCRIPTION
This adds a small public loading API so callers can load and validate config from YAML strings or files through `Ucfg`, without manually composing lower-level components.

## What changed
- Added `Ucfg.load_yaml(source, erb: false)` to optionally render ERB (opt-in) and then parse YAML.
- Added `Ucfg.load_file(path, erb: false)` to read file content and delegate to `load_yaml`.
- Added `Ucfg.validate_file(path, schema, erb: false)` to load from file and reuse existing `validate`.
- Kept `Ucfg.validate(config, schema)` unchanged.
- Kept `Ucfg.validate_yaml(source, schema)` compatible by delegating to `load_yaml(source)` with default non-ERB behavior.

## Notes
- ERB remains disabled by default everywhere.
- No multi-file loading or deep-merge behavior was added.
- Added focused specs for `load_yaml`, `load_file`, `validate_file`, and existing `validate_yaml` compatibility.