### PR TITLE
Add deterministic standalone config deep merger

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -6,6 +6,7 @@ require "ucfg/validation_result"
 require "ucfg/file_loader"
 require "ucfg/template_renderer"
 require "ucfg/yaml_loader"
+require "ucfg/config_merger"
 
 module Ucfg
   class Error < StandardError; end

--- a/lib/ucfg/config_merger.rb
+++ b/lib/ucfg/config_merger.rb
@@ -39,6 +39,8 @@ module Ucfg
           value.each_with_object({}) { |(key, nested), copy| copy[key] = deep_clone(nested) }
         when Array
           value.map { |item| deep_clone(item) }
+        when String
+          value.dup
         else
           value
         end

--- a/lib/ucfg/config_merger.rb
+++ b/lib/ucfg/config_merger.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Ucfg
+  module ConfigMerger
+    class << self
+      def merge(base, override)
+        merge_hashes(normalize_input(base, "base"), normalize_input(override, "override"))
+      end
+
+      private
+
+      def normalize_input(value, label)
+        return {} if value.nil?
+        return value if value.is_a?(Hash)
+
+        raise Error, "#{label.capitalize} config must be a Hash or nil"
+      end
+
+      def merge_hashes(base, override)
+        merged = deep_clone(base)
+
+        override.each do |key, override_value|
+          base_value = merged[key]
+
+          merged[key] =
+            if base_value.is_a?(Hash) && override_value.is_a?(Hash)
+              merge_hashes(base_value, override_value)
+            else
+              deep_clone(override_value)
+            end
+        end
+
+        merged
+      end
+
+      def deep_clone(value)
+        case value
+        when Hash
+          value.each_with_object({}) { |(key, nested), copy| copy[key] = deep_clone(nested) }
+        when Array
+          value.map { |item| deep_clone(item) }
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/spec/config_merger_spec.rb
+++ b/spec/config_merger_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.describe Ucfg::ConfigMerger do
+  describe ".merge" do
+    it "prefers override values for matching scalar keys" do
+      merged = described_class.merge({ "a" => 1 }, { "a" => 2 })
+
+      expect(merged).to eq({ "a" => 2 })
+    end
+
+    it "deep merges nested hashes" do
+      merged = described_class.merge(
+        { "a" => { "b" => 1 } },
+        { "a" => { "c" => 2 } }
+      )
+
+      expect(merged).to eq({ "a" => { "b" => 1, "c" => 2 } })
+    end
+
+    it "applies nil values from the override" do
+      merged = described_class.merge(
+        { "a" => { "b" => 1, "c" => 2 } },
+        { "a" => { "b" => nil } }
+      )
+
+      expect(merged).to eq({ "a" => { "b" => nil, "c" => 2 } })
+    end
+
+    it "replaces arrays instead of concatenating them" do
+      merged = described_class.merge(
+        { "a" => [1, 2] },
+        { "a" => [3] }
+      )
+
+      expect(merged).to eq({ "a" => [3] })
+    end
+
+    it "treats nil input as an empty hash" do
+      expect(described_class.merge(nil, nil)).to eq({})
+      expect(described_class.merge(nil, { "a" => 1 })).to eq({ "a" => 1 })
+      expect(described_class.merge({ "a" => 1 }, nil)).to eq({ "a" => 1 })
+    end
+
+    it "raises Ucfg::Error when base is non-nil and not a hash" do
+      expect { described_class.merge([], {}) }
+        .to raise_error(Ucfg::Error, /base config must be a hash or nil/i)
+    end
+
+    it "raises Ucfg::Error when override is non-nil and not a hash" do
+      expect { described_class.merge({}, []) }
+        .to raise_error(Ucfg::Error, /override config must be a hash or nil/i)
+    end
+
+    it "does not mutate either input hash" do
+      base = {
+        "nested" => { "value" => 1 },
+        "array" => [1, 2]
+      }
+      override = {
+        "nested" => { "other" => 2 },
+        "array" => [3]
+      }
+
+      base_before = Marshal.load(Marshal.dump(base))
+      override_before = Marshal.load(Marshal.dump(override))
+
+      described_class.merge(base, override)
+
+      expect(base).to eq(base_before)
+      expect(override).to eq(override_before)
+    end
+
+    it "preserves string and symbol keys as-is" do
+      merged = described_class.merge(
+        { "a" => 1, b: 2 },
+        { "a" => 3, b: 4, c: 5, "d" => 6 }
+      )
+
+      expect(merged).to eq({ "a" => 3, b: 4, c: 5, "d" => 6 })
+      expect(merged.keys).to contain_exactly("a", :b, :c, "d")
+    end
+
+    it "returns an independent merged hash" do
+      base = { "a" => { "b" => 1 }, "arr" => [1, 2] }
+      override = { "a" => { "c" => 2 }, "arr" => [3] }
+
+      merged = described_class.merge(base, override)
+      merged["a"]["b"] = 99
+      merged["arr"] << 4
+
+      expect(base).to eq({ "a" => { "b" => 1 }, "arr" => [1, 2] })
+      expect(override).to eq({ "a" => { "c" => 2 }, "arr" => [3] })
+    end
+  end
+end

--- a/spec/config_merger_spec.rb
+++ b/spec/config_merger_spec.rb
@@ -81,15 +81,17 @@ RSpec.describe Ucfg::ConfigMerger do
     end
 
     it "returns an independent merged hash" do
-      base = { "a" => { "b" => 1 }, "arr" => [1, 2] }
-      override = { "a" => { "c" => 2 }, "arr" => [3] }
+      base = { "a" => { "b" => 1 }, "arr" => [1, 2], "name" => "base-name" }
+      override = { "a" => { "c" => 2 }, "arr" => [3], "title" => "override-title" }
 
       merged = described_class.merge(base, override)
       merged["a"]["b"] = 99
       merged["arr"] << 4
+      merged["name"] << "-changed"
+      merged["title"] << "-changed"
 
-      expect(base).to eq({ "a" => { "b" => 1 }, "arr" => [1, 2] })
-      expect(override).to eq({ "a" => { "c" => 2 }, "arr" => [3] })
+      expect(base).to eq({ "a" => { "b" => 1 }, "arr" => [1, 2], "name" => "base-name" })
+      expect(override).to eq({ "a" => { "c" => 2 }, "arr" => [3], "title" => "override-title" })
     end
   end
 end


### PR DESCRIPTION
## Why
The gem needed a standalone way to combine already-loaded config hashes without wiring together file loading, ERB rendering, YAML parsing, or schema validation. This adds a deterministic merge utility focused only on hash data.

## What changed
- Added `Ucfg::ConfigMerger.merge(base, override)` in `lib/ucfg/config_merger.rb`.
- Implemented recursive hash merging where override values win.
- Kept merge behavior explicit and predictable:
  - Arrays are replaced, not concatenated.
  - Scalars are replaced.
  - `nil` in override replaces existing values.
  - `nil` inputs are treated as empty hashes.
  - Non-`nil` non-hash inputs raise `Ucfg::Error`.
  - String and symbol keys are preserved as-is.
- Made the merge non-mutating by deep-cloning nested hashes/arrays.
- Added focused specs in `spec/config_merger_spec.rb` covering all required behaviors and non-mutation guarantees.
- Required the new component from `lib/ucfg.rb`.