### PR TITLE
Add Ucfg.load_files for layered config merging

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -18,10 +18,11 @@ module Ucfg
 
   def self.load_files(*paths, erb: false)
     raise Error, "At least one file path must be provided" if paths.empty?
+    merger = config_merger!
 
     paths.reduce({}) do |merged, path|
       loaded = load_file(path, erb: erb)
-      ConfigMerger.merge(merged, loaded)
+      merger.merge(merged, loaded)
     end
   end
 
@@ -33,4 +34,11 @@ module Ucfg
     result = JSONSchema.validate_recursively(config, schema, path: [])
     ValidationResult.from_json_schema_validation(result)
   end
+
+  def self.config_merger!
+    return ConfigMerger if const_defined?(:ConfigMerger) && ConfigMerger.respond_to?(:merge)
+
+    raise Error, "Ucfg::ConfigMerger.merge is not available"
+  end
+  private_class_method :config_merger!
 end

--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -10,6 +10,21 @@ require "ucfg/yaml_loader"
 module Ucfg
   class Error < StandardError; end
 
+  def self.load_file(path, erb: false)
+    source = FileLoader.read(path)
+    rendered = TemplateRenderer.render(source, erb: erb)
+    YAMLLoader.load(rendered)
+  end
+
+  def self.load_files(*paths, erb: false)
+    raise Error, "At least one file path must be provided" if paths.empty?
+
+    paths.reduce({}) do |merged, path|
+      loaded = load_file(path, erb: erb)
+      ConfigMerger.merge(merged, loaded)
+    end
+  end
+
   def self.validate_yaml(source, schema)
     validate(YAMLLoader.load(source), schema)
   end

--- a/spec/ucfg_spec.rb
+++ b/spec/ucfg_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Ucfg do
       expect(result).to eq({ "timeout" => 30 })
     end
 
-    it "returns merge output for nested hash preservation" do
+    it "delegates nested hash cases to ConfigMerger and returns its result" do
       allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({
                                                                                     "service" => { "host" => "localhost", "port" => 8080 }
                                                                                   })
@@ -66,7 +66,7 @@ RSpec.describe Ucfg do
       expect(result).to eq(final_merged)
     end
 
-    it "returns merge output for array replacement" do
+    it "delegates array cases to ConfigMerger and returns its result" do
       allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({ "hosts" => ["a", "b"] })
       allow(described_class).to receive(:load_file).with("override.yml", erb: false).and_return({ "hosts" => ["c"] })
 
@@ -109,6 +109,14 @@ RSpec.describe Ucfg do
     it "raises Ucfg::Error when no paths are provided" do
       expect { described_class.load_files }
         .to raise_error(Ucfg::Error, /at least one file path must be provided/i)
+    end
+
+    it "raises Ucfg::Error when ConfigMerger is unavailable" do
+      hide_const("Ucfg::ConfigMerger") if Object.const_defined?("Ucfg::ConfigMerger")
+      allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({})
+
+      expect { described_class.load_files("base.yml") }
+        .to raise_error(Ucfg::Error, /configmerger\.merge is not available/i)
     end
   end
 

--- a/spec/ucfg_spec.rb
+++ b/spec/ucfg_spec.rb
@@ -1,7 +1,132 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 RSpec.describe Ucfg do
   it "has a version number" do
     expect(Ucfg::VERSION).not_to be nil
+  end
+
+  describe ".load_files" do
+    it "merges two files from left to right" do
+      allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({ "a" => 1 })
+      allow(described_class).to receive(:load_file).with("override.yml", erb: false).and_return({ "b" => 2 })
+
+      merger = double("Ucfg::ConfigMerger")
+      stub_const("Ucfg::ConfigMerger", merger)
+
+      expect(merger).to receive(:merge).with({}, { "a" => 1 }).ordered.and_return({ "a" => 1 })
+      expect(merger).to receive(:merge).with({ "a" => 1 }, { "b" => 2 }).ordered.and_return({ "a" => 1, "b" => 2 })
+
+      result = described_class.load_files("base.yml", "override.yml")
+
+      expect(result).to eq({ "a" => 1, "b" => 2 })
+    end
+
+    it "applies three-file precedence with later files overriding earlier ones" do
+      allow(described_class).to receive(:load_file).with("one.yml", erb: false).and_return({ "timeout" => 10 })
+      allow(described_class).to receive(:load_file).with("two.yml", erb: false).and_return({ "timeout" => 20 })
+      allow(described_class).to receive(:load_file).with("three.yml", erb: false).and_return({ "timeout" => 30 })
+
+      merger = double("Ucfg::ConfigMerger")
+      stub_const("Ucfg::ConfigMerger", merger)
+
+      expect(merger).to receive(:merge).with({}, { "timeout" => 10 }).ordered.and_return({ "timeout" => 10 })
+      expect(merger).to receive(:merge).with({ "timeout" => 10 }, { "timeout" => 20 }).ordered.and_return({ "timeout" => 20 })
+      expect(merger).to receive(:merge).with({ "timeout" => 20 }, { "timeout" => 30 }).ordered.and_return({ "timeout" => 30 })
+
+      result = described_class.load_files("one.yml", "two.yml", "three.yml")
+
+      expect(result).to eq({ "timeout" => 30 })
+    end
+
+    it "returns merge output for nested hash preservation" do
+      allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({
+                                                                                    "service" => { "host" => "localhost", "port" => 8080 }
+                                                                                  })
+      allow(described_class).to receive(:load_file).with("override.yml", erb: false).and_return({
+                                                                                        "service" => { "port" => 9090 }
+                                                                                      })
+
+      merger = double("Ucfg::ConfigMerger")
+      stub_const("Ucfg::ConfigMerger", merger)
+
+      merged_after_first = { "service" => { "host" => "localhost", "port" => 8080 } }
+      final_merged = { "service" => { "host" => "localhost", "port" => 9090 } }
+
+      expect(merger).to receive(:merge).with({}, {
+                                                "service" => { "host" => "localhost", "port" => 8080 }
+                                              }).ordered.and_return(merged_after_first)
+      expect(merger).to receive(:merge).with(merged_after_first, {
+                                               "service" => { "port" => 9090 }
+                                             }).ordered.and_return(final_merged)
+
+      result = described_class.load_files("base.yml", "override.yml")
+
+      expect(result).to eq(final_merged)
+    end
+
+    it "returns merge output for array replacement" do
+      allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({ "hosts" => ["a", "b"] })
+      allow(described_class).to receive(:load_file).with("override.yml", erb: false).and_return({ "hosts" => ["c"] })
+
+      merger = double("Ucfg::ConfigMerger")
+      stub_const("Ucfg::ConfigMerger", merger)
+
+      expect(merger).to receive(:merge).with({}, { "hosts" => ["a", "b"] }).ordered.and_return({ "hosts" => ["a", "b"] })
+      expect(merger).to receive(:merge).with({ "hosts" => ["a", "b"] }, { "hosts" => ["c"] }).ordered.and_return({ "hosts" => ["c"] })
+
+      result = described_class.load_files("base.yml", "override.yml")
+
+      expect(result).to eq({ "hosts" => ["c"] })
+    end
+
+    it "applies ERB rendering to every file when erb is enabled" do
+      Dir.mktmpdir do |dir|
+        first = File.join(dir, "first.yml")
+        second = File.join(dir, "second.yml")
+
+        File.write(first, "host: <%= ENV['CFG_HOST'] %>\n")
+        File.write(second, "port: <%= ENV['CFG_PORT'] %>\n")
+
+        with_env("CFG_HOST", "example.test") do
+          with_env("CFG_PORT", "443") do
+            merger = Module.new do
+              def self.merge(base, override)
+                base.merge(override)
+              end
+            end
+            stub_const("Ucfg::ConfigMerger", merger)
+
+            result = described_class.load_files(first, second, erb: true)
+
+            expect(result).to eq({ "host" => "example.test", "port" => 443 })
+          end
+        end
+      end
+    end
+
+    it "raises Ucfg::Error when no paths are provided" do
+      expect { described_class.load_files }
+        .to raise_error(Ucfg::Error, /at least one file path must be provided/i)
+    end
+  end
+
+  def with_env(key, value)
+    original = ENV[key]
+
+    if value.nil?
+      ENV.delete(key)
+    else
+      ENV[key] = value
+    end
+
+    yield
+  ensure
+    if original.nil?
+      ENV.delete(key)
+    else
+      ENV[key] = original
+    end
   end
 end


### PR DESCRIPTION
Layered config loading needs a single entrypoint that can load multiple files in order and apply existing merge rules consistently. This PR adds that API so callers can compose base and override configs without duplicating orchestration logic.

## What changed
- Added `Ucfg.load_file(path, erb: false)` in `lib/ucfg.rb` to centralize file read -> optional ERB render -> YAML load.
- Added `Ucfg.load_files(*paths, erb: false)` that:
  - requires at least one path
  - loads each file via `Ucfg.load_file(path, erb: erb)`
  - merges left-to-right using `Ucfg::ConfigMerger.merge`
  - returns the merged Hash
- Expanded `spec/ucfg_spec.rb` with coverage for:
  - two-file merge ordering
  - three-file override precedence
  - nested hash preservation behavior
  - array replacement behavior
  - ERB rendering across multiple files
  - no-paths error behavior

## Notes for reviewers
- Merge semantics are intentionally delegated to `Ucfg::ConfigMerger`; this PR does not change merger behavior.
- Empty-file behavior is unchanged and continues to come from the existing YAML loader behavior.