### PR TITLE
Add JSON Schema minimum/maximum numeric aliases

### DIFF
--- a/lib/ucfg/json_schema/max.rb
+++ b/lib/ucfg/json_schema/max.rb
@@ -36,6 +36,8 @@ module Ucfg
         def handled_by_min_max?(schema)
           schema.key?("min") &&
             schema.key?("max") &&
+            schema["min"].is_a?(Numeric) &&
+            schema["max"].is_a?(Numeric) &&
             !schema.key?("minimum") &&
             !schema.key?("maximum") &&
             !schema.key?("exclusiveMinimum") &&

--- a/lib/ucfg/json_schema/max.rb
+++ b/lib/ucfg/json_schema/max.rb
@@ -5,16 +5,41 @@ require "ucfg/json_schema"
 module Ucfg
   module JSONSchema
     class Max
+      MAX_KEYWORDS = [
+        ["max", :>=, "less than or equal to"],
+        ["maximum", :>=, "less than or equal to"],
+        ["exclusiveMaximum", :>, "less than"],
+      ].freeze
+
       class << self
         def validate(instance, schema, path:)
-          return if schema.key?("min")
-          return unless schema.key?("max")
           return unless instance.is_a?(Numeric)
-          return unless schema["max"].is_a?(Numeric)
+          return if handled_by_min_max?(schema)
 
-          return if schema["max"] >= instance
+          errors = MAX_KEYWORDS.each_with_object([]) do |(keyword, operator, text), memo|
+            next unless schema.key?(keyword)
+            next unless schema[keyword].is_a?(Numeric)
 
-          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must be less than or equal to #{schema['max']} (provided #{instance})")
+            valid = schema[keyword].public_send(operator, instance)
+            next if valid
+
+            memo << "Property `#{path.join('.')}` must be #{text} #{schema[keyword]} (provided #{instance})"
+          end
+
+          return if errors.empty?
+
+          { validation_errors: errors }
+        end
+
+        private
+
+        def handled_by_min_max?(schema)
+          schema.key?("min") &&
+            schema.key?("max") &&
+            !schema.key?("minimum") &&
+            !schema.key?("maximum") &&
+            !schema.key?("exclusiveMinimum") &&
+            !schema.key?("exclusiveMaximum")
         end
       end
     end

--- a/lib/ucfg/json_schema/min.rb
+++ b/lib/ucfg/json_schema/min.rb
@@ -36,6 +36,8 @@ module Ucfg
         def handled_by_min_max?(schema)
           schema.key?("min") &&
             schema.key?("max") &&
+            schema["min"].is_a?(Numeric) &&
+            schema["max"].is_a?(Numeric) &&
             !schema.key?("minimum") &&
             !schema.key?("maximum") &&
             !schema.key?("exclusiveMinimum") &&

--- a/lib/ucfg/json_schema/min.rb
+++ b/lib/ucfg/json_schema/min.rb
@@ -5,16 +5,41 @@ require "ucfg/json_schema"
 module Ucfg
   module JSONSchema
     class Min
+      MIN_KEYWORDS = [
+        ["min", :<=, "greater than or equal to"],
+        ["minimum", :<=, "greater than or equal to"],
+        ["exclusiveMinimum", :<, "greater than"],
+      ].freeze
+
       class << self
         def validate(instance, schema, path:)
-          return if schema.key?("max")
-          return unless schema.key?("min")
           return unless instance.is_a?(Numeric)
-          return unless schema["min"].is_a?(Numeric)
+          return if handled_by_min_max?(schema)
 
-          return if schema["min"] <= instance
+          errors = MIN_KEYWORDS.each_with_object([]) do |(keyword, operator, text), memo|
+            next unless schema.key?(keyword)
+            next unless schema[keyword].is_a?(Numeric)
 
-          JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must be greater than or equal to #{schema['min']} (provided #{instance})")
+            valid = schema[keyword].public_send(operator, instance)
+            next if valid
+
+            memo << "Property `#{path.join('.')}` must be #{text} #{schema[keyword]} (provided #{instance})"
+          end
+
+          return if errors.empty?
+
+          { validation_errors: errors }
+        end
+
+        private
+
+        def handled_by_min_max?(schema)
+          schema.key?("min") &&
+            schema.key?("max") &&
+            !schema.key?("minimum") &&
+            !schema.key?("maximum") &&
+            !schema.key?("exclusiveMinimum") &&
+            !schema.key?("exclusiveMaximum")
         end
       end
     end

--- a/lib/ucfg/json_schema/min_max.rb
+++ b/lib/ucfg/json_schema/min_max.rb
@@ -7,6 +7,7 @@ module Ucfg
     class MinMax
       class << self
         def validate(instance, schema, path:)
+          return unless exact_legacy_range?(schema)
           return unless schema.key?("min")
           return unless schema.key?("max")
           return unless schema["min"].is_a?(Numeric)
@@ -16,6 +17,15 @@ module Ucfg
           return if schema["min"] <= instance && schema["max"] >= instance
 
           JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must be between #{schema['min']} and #{schema['max']} (provided #{instance})")
+        end
+
+        def exact_legacy_range?(schema)
+          schema.key?("min") &&
+            schema.key?("max") &&
+            !schema.key?("minimum") &&
+            !schema.key?("maximum") &&
+            !schema.key?("exclusiveMinimum") &&
+            !schema.key?("exclusiveMaximum")
         end
       end
     end

--- a/spec/numeric_validation_spec.rb
+++ b/spec/numeric_validation_spec.rb
@@ -71,6 +71,38 @@ RSpec.describe "Numeric validation" do
     expect(Ucfg.validate({ "a" => 4 }, schema_as_hash).errors).to eq(["Property `a` must be less than or equal to 3 (provided 4)"])
   end
 
+  it "supports exclusive minimum alias" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "exclusiveMinimum": 3
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 4 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 3 }, schema_as_hash).errors).to eq(["Property `a` must be greater than 3 (provided 3)"])
+  end
+
+  it "supports exclusive maximum alias" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "exclusiveMaximum": 3
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 2 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 3 }, schema_as_hash).errors).to eq(["Property `a` must be less than 3 (provided 3)"])
+  end
+
   it "supports range" do
     schema = <<-JSON
     {
@@ -133,6 +165,62 @@ RSpec.describe "Numeric validation" do
         "Property `a` must be less than or equal to 3 (provided 9)",
       ],
     )
+  end
+
+  it "does not emit legacy range error when min/max are combined with minimum/maximum" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "min": 1,
+          "max": 9,
+          "minimum": 3,
+          "maximum": 7
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 8 }, schema_as_hash).errors).to eq(["Property `a` must be less than or equal to 7 (provided 8)"])
+    expect(Ucfg.validate({ "a" => 0 }, schema_as_hash).errors).to eq(
+      [
+        "Property `a` must be greater than or equal to 1 (provided 0)",
+        "Property `a` must be greater than or equal to 3 (provided 0)",
+      ],
+    )
+  end
+
+  it "does not skip min when max is non-numeric" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "min": 3,
+          "max": "9"
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 2 }, schema_as_hash).errors).to eq(["Property `a` must be greater than or equal to 3 (provided 2)"])
+  end
+
+  it "does not skip max when min is non-numeric" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "min": "1",
+          "max": 3
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 4 }, schema_as_hash).errors).to eq(["Property `a` must be less than or equal to 3 (provided 4)"])
   end
 
   it "ignores minimum and maximum when instance is not numeric" do

--- a/spec/numeric_validation_spec.rb
+++ b/spec/numeric_validation_spec.rb
@@ -3,7 +3,7 @@
 require "json"
 
 RSpec.describe "Numeric validation" do
-  it "supports minimum" do
+  it "supports min" do
     schema = <<-JSON
     {
       "properties": {
@@ -20,12 +20,46 @@ RSpec.describe "Numeric validation" do
     expect(Ucfg.validate({ "a" => 2 }, schema_as_hash).errors).to eq(["Property `a` must be greater than or equal to 3 (provided 2)"])
   end
 
-  it "supports maximum" do
+  it "supports minimum alias" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "minimum": 3
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 3 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 4 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 2 }, schema_as_hash).errors).to eq(["Property `a` must be greater than or equal to 3 (provided 2)"])
+  end
+
+  it "supports max" do
     schema = <<-JSON
     {
       "properties": {
         "a": {
           "max": 3
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 2 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 3 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 4 }, schema_as_hash).errors).to eq(["Property `a` must be less than or equal to 3 (provided 4)"])
+  end
+
+  it "supports maximum alias" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "maximum": 3
         }
       }
     }
@@ -53,5 +87,83 @@ RSpec.describe "Numeric validation" do
     expect(Ucfg.validate({ "a" => -10 }, schema_as_hash)).to be_valid
     expect(Ucfg.validate({ "a" => 3 }, schema_as_hash)).to be_valid
     expect(Ucfg.validate({ "a" => 4 }, schema_as_hash).errors).to eq(["Property `a` must be between -20 and 3 (provided 4)"])
+  end
+
+  it "validates both min and minimum when both are present" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "min": 1,
+          "minimum": 3
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 3 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 2 }, schema_as_hash).errors).to eq(["Property `a` must be greater than or equal to 3 (provided 2)"])
+    expect(Ucfg.validate({ "a" => 0 }, schema_as_hash).errors).to eq(
+      [
+        "Property `a` must be greater than or equal to 1 (provided 0)",
+        "Property `a` must be greater than or equal to 3 (provided 0)",
+      ],
+    )
+  end
+
+  it "validates both max and maximum when both are present" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "max": 8,
+          "maximum": 3
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 3 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 5 }, schema_as_hash).errors).to eq(["Property `a` must be less than or equal to 3 (provided 5)"])
+    expect(Ucfg.validate({ "a" => 9 }, schema_as_hash).errors).to eq(
+      [
+        "Property `a` must be less than or equal to 8 (provided 9)",
+        "Property `a` must be less than or equal to 3 (provided 9)",
+      ],
+    )
+  end
+
+  it "ignores minimum and maximum when instance is not numeric" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "minimum": 1,
+          "maximum": 2
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => "text" }, schema_as_hash)).to be_valid
+  end
+
+  it "ignores invalid minimum and maximum schema values" do
+    schema = <<-JSON
+    {
+      "properties": {
+        "a": {
+          "minimum": "1",
+          "maximum": null
+        }
+      }
+    }
+    JSON
+    schema_as_hash = JSON.parse(schema)
+
+    expect(Ucfg.validate({ "a" => 99 }, schema_as_hash)).to be_valid
   end
 end


### PR DESCRIPTION
Practical JSON Schema documents commonly use `minimum` and `maximum`, but this validator only handled custom `min` and `max`. This change adds compatibility so schemas using standard numeric keywords validate correctly without breaking existing behavior.

## What changed
- Added `minimum` support as an inclusive lower bound, equivalent to `min`.
- Added `maximum` support as an inclusive upper bound, equivalent to `max`.
- Added `exclusiveMinimum` and `exclusiveMaximum` support with strict comparisons, consistent with the same numeric validation style.
- Preserved legacy `min` + `max` range handling (`between ... and ...`) by deferring to the existing `MinMax` validator for that exact legacy pair.
- Defined deterministic coexistence behavior: when both custom and standard bounds are present (for example `min` + `minimum`, `max` + `maximum`), all present numeric constraints are validated.
- Kept existing behavior of ignoring these numeric keywords when the instance is not numeric and when keyword values in schema are not numeric.

## Test coverage
- Added specs for valid and invalid `minimum` and `maximum`.
- Added specs for coexistence with existing `min` and `max`.
- Added specs confirming non-numeric instances and invalid schema keyword values are ignored consistently.