### PR TITLE
Improve JSON schema validation composition

### DIFF
--- a/lib/ucfg.rb
+++ b/lib/ucfg.rb
@@ -34,7 +34,7 @@ module Ucfg
     raise Error, "At least one file path must be provided" if paths.empty?
 
     paths.reduce({}) do |merged, path|
-      loaded = env ? load_file(path, erb: erb, env: true) : load_file(path, erb: erb)
+      loaded = load_file(path, erb: erb, env: env)
       ConfigMerger.merge(merged, loaded)
     end
   end

--- a/lib/ucfg/json_schema.rb
+++ b/lib/ucfg/json_schema.rb
@@ -81,7 +81,7 @@ module Ucfg
       def compile_pattern_properties(pattern_properties, path:)
         pattern_properties.reduce([[], empty_result]) do |(compiled_patterns, errors), (pattern, sub_schema)|
           unless sub_schema.is_a?(Hash)
-            result = schema_error(path + [pattern.to_s], "schema", "must be an object")
+            result = result_with_validation_error("Schema keyword `#{(path + [pattern.to_s]).join('.')}` must be an object")
             errors = combine_results(errors, result)
             next [compiled_patterns, errors]
           end

--- a/lib/ucfg/json_schema.rb
+++ b/lib/ucfg/json_schema.rb
@@ -24,30 +24,36 @@ require "ucfg/validation_result"
 
 module Ucfg
   module JSONSchema
+    VALIDATORS = [
+      JSONSchema::PatternProperties,
+      JSONSchema::AdditionalProperties,
+      JSONSchema::AllOf,
+      JSONSchema::AnyOf,
+      JSONSchema::Const,
+      JSONSchema::Enum,
+      JSONSchema::Items,
+      JSONSchema::Max,
+      JSONSchema::MaxItems,
+      JSONSchema::MaxLength,
+      JSONSchema::Min,
+      JSONSchema::MinMax,
+      JSONSchema::MinItems,
+      JSONSchema::MinLength,
+      JSONSchema::Pattern,
+      JSONSchema::OneOf,
+      JSONSchema::Required,
+      JSONSchema::Type,
+      JSONSchema::UniqueItems,
+      JSONSchema::Properties,
+    ].freeze
+
     class << self
       def validate_recursively(instance, schema, path:)
-        [
-          JSONSchema::AdditionalProperties,
-          JSONSchema::AllOf,
-          JSONSchema::AnyOf,
-          JSONSchema::Const,
-          JSONSchema::Enum,
-          JSONSchema::Items,
-          JSONSchema::Max,
-          JSONSchema::MaxItems,
-          JSONSchema::MaxLength,
-          JSONSchema::Min,
-          JSONSchema::MinMax,
-          JSONSchema::MinItems,
-          JSONSchema::MinLength,
-          JSONSchema::Pattern,
-          JSONSchema::OneOf,
-          JSONSchema::PatternProperties,
-          JSONSchema::Required,
-          JSONSchema::Type,
-          JSONSchema::UniqueItems,
-          JSONSchema::Properties,
-        ].reduce(empty_result) do |memo, validator|
+        unless schema.is_a?(Hash)
+          return schema_error(path, "schema", "must be an object")
+        end
+
+        VALIDATORS.reduce(empty_result) do |memo, validator|
           result = validator.validate(instance, schema, path: path)
           combine_results(memo, result)
         end
@@ -57,19 +63,29 @@ module Ucfg
         return a if b.nil?
         return b if a.nil?
 
-        { validation_errors: a.fetch(:validation_errors) + b.fetch(:validation_errors) }
+        ValidationResult.new(validation_errors: a.validation_errors + b.validation_errors)
       end
 
       def empty_result
-        { validation_errors: [] }
+        ValidationResult.new
       end
 
       def result_with_validation_error(message)
-        { validation_errors: [message] }
+        ValidationResult.new(validation_errors: [message])
+      end
+
+      def schema_error(path, keyword, expectation)
+        result_with_validation_error("Schema keyword `#{schema_path(path, keyword)}` #{expectation}")
       end
 
       def compile_pattern_properties(pattern_properties, path:)
         pattern_properties.reduce([[], empty_result]) do |(compiled_patterns, errors), (pattern, sub_schema)|
+          unless sub_schema.is_a?(Hash)
+            result = schema_error(path + [pattern.to_s], "schema", "must be an object")
+            errors = combine_results(errors, result)
+            next [compiled_patterns, errors]
+          end
+
           begin
             compiled_patterns << [Regexp.new(pattern), sub_schema]
           rescue RegexpError, TypeError
@@ -79,6 +95,10 @@ module Ucfg
 
           [compiled_patterns, errors]
         end
+      end
+
+      def schema_path(path, keyword)
+        (path + [keyword]).join(".")
       end
     end
   end

--- a/lib/ucfg/json_schema/additional_properties.rb
+++ b/lib/ucfg/json_schema/additional_properties.rb
@@ -8,11 +8,18 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("additionalProperties")
+
+          unless [true, false].include?(schema["additionalProperties"]) || schema["additionalProperties"].is_a?(Hash)
+            return JSONSchema.schema_error(path, "additionalProperties", "must be a boolean or object")
+          end
+
           return unless instance.is_a?(Hash)
 
           explicit_properties = schema["properties"].is_a?(Hash) ? schema["properties"] : {}
           pattern_properties = schema["patternProperties"].is_a?(Hash) ? schema["patternProperties"] : {}
-          compiled_patterns, _ = JSONSchema.compile_pattern_properties(pattern_properties, path: path + ["patternProperties"])
+          compiled_patterns, pattern_errors = JSONSchema.compile_pattern_properties(pattern_properties, path: path + ["patternProperties"])
+          return JSONSchema.empty_result unless pattern_errors.valid?
+
           key_matches_pattern = ->(key) { compiled_patterns.any? { |regex, _| regex.match?(key.to_s) } }
 
           if schema["additionalProperties"] == false

--- a/lib/ucfg/json_schema/all_of.rb
+++ b/lib/ucfg/json_schema/all_of.rb
@@ -8,12 +8,18 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("allOf")
-          return unless schema["allOf"].is_a?(Array)
 
-          schema["allOf"].reduce(JSONSchema.empty_result) do |memo, subschema|
-            next memo unless subschema.is_a?(Hash)
+          unless schema["allOf"].is_a?(Array)
+            return JSONSchema.schema_error(path, "allOf", "must be an array of schemas")
+          end
 
-            result = JSONSchema.validate_recursively(instance, subschema, path: path)
+          schema["allOf"].each_with_index.reduce(JSONSchema.empty_result) do |memo, (subschema, index)|
+            result =
+              if subschema.is_a?(Hash)
+                JSONSchema.validate_recursively(instance, subschema, path: path)
+              else
+                JSONSchema.schema_error(path + ["allOf"], index, "must be an object")
+              end
             JSONSchema.combine_results(memo, result)
           end
         end

--- a/lib/ucfg/json_schema/any_of.rb
+++ b/lib/ucfg/json_schema/any_of.rb
@@ -8,7 +8,13 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("anyOf")
-          return unless schema["anyOf"].is_a?(Array)
+
+          unless schema["anyOf"].is_a?(Array)
+            return JSONSchema.schema_error(path, "anyOf", "must be an array of schemas")
+          end
+
+          schema_errors = invalid_subschema_errors(schema["anyOf"], path: path)
+          return schema_errors unless schema_errors.valid?
 
           return if matching_subschema_count(instance, schema["anyOf"], path: path) > 0
 
@@ -17,12 +23,17 @@ module Ucfg
 
         private
 
+        def invalid_subschema_errors(subschemas, path:)
+          subschemas.each_with_index.reduce(JSONSchema.empty_result) do |memo, (subschema, index)|
+            result = JSONSchema.schema_error(path + ["anyOf"], index, "must be an object") unless subschema.is_a?(Hash)
+            JSONSchema.combine_results(memo, result)
+          end
+        end
+
         def matching_subschema_count(instance, subschemas, path:)
           subschemas.count do |subschema|
-            next false unless subschema.is_a?(Hash)
-
             result = JSONSchema.validate_recursively(instance, subschema, path: path)
-            result.fetch(:validation_errors).empty?
+            result.valid?
           end
         end
       end

--- a/lib/ucfg/json_schema/enum.rb
+++ b/lib/ucfg/json_schema/enum.rb
@@ -8,7 +8,11 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("enum")
-          return unless schema["enum"].is_a?(Array)
+
+          unless schema["enum"].is_a?(Array)
+            return JSONSchema.schema_error(path, "enum", "must be an array")
+          end
+
           return if schema["enum"].include?(instance)
 
           JSONSchema.result_with_validation_error("Property `#{path.join('.')}` contains an unsupported value (provided `#{instance}`)")

--- a/lib/ucfg/json_schema/items.rb
+++ b/lib/ucfg/json_schema/items.rb
@@ -8,13 +8,16 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("items")
+
+          unless schema["items"].is_a?(Hash)
+            return JSONSchema.schema_error(path, "items", "must be an object")
+          end
+
           return unless instance.is_a?(Array)
 
-          if schema["items"].is_a?(Hash)
-            instance.each_with_index.reduce(JSONSchema.empty_result) do |memo, (item, index)|
-              result = JSONSchema.validate_recursively(item, schema["items"], path: path + [index])
-              JSONSchema.combine_results(memo, result)
-            end
+          instance.each_with_index.reduce(JSONSchema.empty_result) do |memo, (item, index)|
+            result = JSONSchema.validate_recursively(item, schema["items"], path: path + [index])
+            JSONSchema.combine_results(memo, result)
           end
         end
       end

--- a/lib/ucfg/json_schema/max.rb
+++ b/lib/ucfg/json_schema/max.rb
@@ -13,12 +13,14 @@ module Ucfg
 
       class << self
         def validate(instance, schema, path:)
+          schema_errors = invalid_keyword_errors(schema, path: path)
+          return schema_errors unless schema_errors.valid?
+
           return unless instance.is_a?(Numeric)
           return if handled_by_min_max?(schema)
 
           errors = MAX_KEYWORDS.each_with_object([]) do |(keyword, operator, text), memo|
             next unless schema.key?(keyword)
-            next unless schema[keyword].is_a?(Numeric)
 
             valid = schema[keyword].public_send(operator, instance)
             next if valid
@@ -28,10 +30,20 @@ module Ucfg
 
           return if errors.empty?
 
-          { validation_errors: errors }
+          ValidationResult.new(validation_errors: errors)
         end
 
         private
+
+        def invalid_keyword_errors(schema, path:)
+          MAX_KEYWORDS.each_with_object(JSONSchema.empty_result) do |(keyword, _, _), memo|
+            next unless schema.key?(keyword)
+            next if schema[keyword].is_a?(Numeric)
+
+            result = JSONSchema.schema_error(path, keyword, "must be a number")
+            memo.merge!(result)
+          end
+        end
 
         def handled_by_min_max?(schema)
           schema.key?("min") &&

--- a/lib/ucfg/json_schema/max_items.rb
+++ b/lib/ucfg/json_schema/max_items.rb
@@ -8,8 +8,12 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("maxItems")
+
+          unless schema["maxItems"].is_a?(Integer) && schema["maxItems"] >= 0
+            return JSONSchema.schema_error(path, "maxItems", "must be a non-negative integer")
+          end
+
           return unless instance.is_a?(Array)
-          return unless schema["maxItems"].is_a?(Integer) && schema["maxItems"] >= 0
 
           return if instance.length <= schema["maxItems"]
 

--- a/lib/ucfg/json_schema/max_length.rb
+++ b/lib/ucfg/json_schema/max_length.rb
@@ -8,8 +8,12 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("maxLength")
+
+          unless schema["maxLength"].is_a?(Integer) && schema["maxLength"] >= 0
+            return JSONSchema.schema_error(path, "maxLength", "must be a non-negative integer")
+          end
+
           return unless instance.is_a?(String)
-          return unless schema["maxLength"].is_a?(Integer) && schema["maxLength"] >= 0
 
           return if instance.length <= schema["maxLength"]
 

--- a/lib/ucfg/json_schema/min.rb
+++ b/lib/ucfg/json_schema/min.rb
@@ -13,12 +13,14 @@ module Ucfg
 
       class << self
         def validate(instance, schema, path:)
+          schema_errors = invalid_keyword_errors(schema, path: path)
+          return schema_errors unless schema_errors.valid?
+
           return unless instance.is_a?(Numeric)
           return if handled_by_min_max?(schema)
 
           errors = MIN_KEYWORDS.each_with_object([]) do |(keyword, operator, text), memo|
             next unless schema.key?(keyword)
-            next unless schema[keyword].is_a?(Numeric)
 
             valid = schema[keyword].public_send(operator, instance)
             next if valid
@@ -28,10 +30,20 @@ module Ucfg
 
           return if errors.empty?
 
-          { validation_errors: errors }
+          ValidationResult.new(validation_errors: errors)
         end
 
         private
+
+        def invalid_keyword_errors(schema, path:)
+          MIN_KEYWORDS.each_with_object(JSONSchema.empty_result) do |(keyword, _, _), memo|
+            next unless schema.key?(keyword)
+            next if schema[keyword].is_a?(Numeric)
+
+            result = JSONSchema.schema_error(path, keyword, "must be a number")
+            memo.merge!(result)
+          end
+        end
 
         def handled_by_min_max?(schema)
           schema.key?("min") &&

--- a/lib/ucfg/json_schema/min_items.rb
+++ b/lib/ucfg/json_schema/min_items.rb
@@ -8,8 +8,12 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("minItems")
+
+          unless schema["minItems"].is_a?(Integer) && schema["minItems"] >= 0
+            return JSONSchema.schema_error(path, "minItems", "must be a non-negative integer")
+          end
+
           return unless instance.is_a?(Array)
-          return unless schema["minItems"].is_a?(Integer) && schema["minItems"] >= 0
 
           return if instance.length >= schema["minItems"]
 

--- a/lib/ucfg/json_schema/min_length.rb
+++ b/lib/ucfg/json_schema/min_length.rb
@@ -8,8 +8,12 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("minLength")
+
+          unless schema["minLength"].is_a?(Integer) && schema["minLength"] >= 0
+            return JSONSchema.schema_error(path, "minLength", "must be a non-negative integer")
+          end
+
           return unless instance.is_a?(String)
-          return unless schema["minLength"].is_a?(Integer) && schema["minLength"] >= 0
 
           return if instance.length >= schema["minLength"]
 

--- a/lib/ucfg/json_schema/min_max.rb
+++ b/lib/ucfg/json_schema/min_max.rb
@@ -8,10 +8,6 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless exact_legacy_range?(schema)
-          return unless schema.key?("min")
-          return unless schema.key?("max")
-          return unless schema["min"].is_a?(Numeric)
-          return unless schema["max"].is_a?(Numeric)
           return unless instance.is_a?(Numeric)
 
           return if schema["min"] <= instance && schema["max"] >= instance
@@ -22,6 +18,8 @@ module Ucfg
         def exact_legacy_range?(schema)
           schema.key?("min") &&
             schema.key?("max") &&
+            schema["min"].is_a?(Numeric) &&
+            schema["max"].is_a?(Numeric) &&
             !schema.key?("minimum") &&
             !schema.key?("maximum") &&
             !schema.key?("exclusiveMinimum") &&

--- a/lib/ucfg/json_schema/one_of.rb
+++ b/lib/ucfg/json_schema/one_of.rb
@@ -8,7 +8,13 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("oneOf")
-          return unless schema["oneOf"].is_a?(Array)
+
+          unless schema["oneOf"].is_a?(Array)
+            return JSONSchema.schema_error(path, "oneOf", "must be an array of schemas")
+          end
+
+          schema_errors = invalid_subschema_errors(schema["oneOf"], path: path)
+          return schema_errors unless schema_errors.valid?
 
           matching_subschemas = matching_subschema_count(instance, schema["oneOf"], path: path)
           return if matching_subschemas == 1
@@ -18,12 +24,17 @@ module Ucfg
 
         private
 
+        def invalid_subschema_errors(subschemas, path:)
+          subschemas.each_with_index.reduce(JSONSchema.empty_result) do |memo, (subschema, index)|
+            result = JSONSchema.schema_error(path + ["oneOf"], index, "must be an object") unless subschema.is_a?(Hash)
+            JSONSchema.combine_results(memo, result)
+          end
+        end
+
         def matching_subschema_count(instance, subschemas, path:)
           subschemas.count do |subschema|
-            next false unless subschema.is_a?(Hash)
-
             result = JSONSchema.validate_recursively(instance, subschema, path: path)
-            result.fetch(:validation_errors).empty?
+            result.valid?
           end
         end
       end

--- a/lib/ucfg/json_schema/pattern.rb
+++ b/lib/ucfg/json_schema/pattern.rb
@@ -8,10 +8,13 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("pattern")
-          return unless instance.is_a?(String)
-          return unless schema["pattern"].is_a?(String)
+
+          unless schema["pattern"].is_a?(String)
+            return JSONSchema.schema_error(path, "pattern", "must be a string")
+          end
 
           regexp = Regexp.new(schema["pattern"])
+          return unless instance.is_a?(String)
           return if instance.match?(regexp)
 
           JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must match pattern `#{schema['pattern']}` (provided `#{instance}`)")

--- a/lib/ucfg/json_schema/pattern_properties.rb
+++ b/lib/ucfg/json_schema/pattern_properties.rb
@@ -8,10 +8,15 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("patternProperties")
-          return unless schema["patternProperties"].is_a?(Hash)
-          return unless instance.is_a?(Hash)
+
+          unless schema["patternProperties"].is_a?(Hash)
+            return JSONSchema.schema_error(path, "patternProperties", "must be an object")
+          end
 
           compiled_patterns, errors = JSONSchema.compile_pattern_properties(schema["patternProperties"], path: path + ["patternProperties"])
+          return errors unless errors.valid?
+
+          return unless instance.is_a?(Hash)
 
           result = instance.reduce(JSONSchema.empty_result) do |memo, (key, value)|
             key_result = compiled_patterns.reduce(JSONSchema.empty_result) do |key_memo, (regex, sub_schema)|

--- a/lib/ucfg/json_schema/properties.rb
+++ b/lib/ucfg/json_schema/properties.rb
@@ -8,11 +8,25 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("properties")
-          return unless schema["properties"].is_a?(Hash)
-          return unless instance.is_a?(Hash)
+
+          unless schema["properties"].is_a?(Hash)
+            return JSONSchema.schema_error(path, "properties", "must be an object")
+          end
+
+          schema_errors = property_schema_errors(schema["properties"], path: path)
+          return schema_errors unless schema_errors.valid?
 
           schema["properties"].reduce(JSONSchema.empty_result) do |memo, (key, sub_schema)|
-            result = JSONSchema.validate_recursively(instance[key], sub_schema, path: path + [key]) if instance.key?(key)
+            result = JSONSchema.validate_recursively(instance[key], sub_schema, path: path + [key]) if instance.is_a?(Hash) && instance.key?(key)
+            JSONSchema.combine_results(memo, result)
+          end
+        end
+
+        private
+
+        def property_schema_errors(properties, path:)
+          properties.reduce(JSONSchema.empty_result) do |memo, (key, sub_schema)|
+            result = JSONSchema.schema_error(path + ["properties"], key, "must be an object") unless sub_schema.is_a?(Hash)
             JSONSchema.combine_results(memo, result)
           end
         end

--- a/lib/ucfg/json_schema/required.rb
+++ b/lib/ucfg/json_schema/required.rb
@@ -8,7 +8,16 @@ module Ucfg
       class << self
         def validate(instance, schema, path:)
           return unless schema.key?("required")
-          return unless schema["required"].is_a?(Array)
+
+          unless schema["required"].is_a?(Array)
+            return JSONSchema.schema_error(path, "required", "must be an array of property names")
+          end
+
+          invalid_required = schema["required"].find { |required_key| !required_key.is_a?(String) }
+          if invalid_required
+            return JSONSchema.schema_error(path, "required", "must contain only property names")
+          end
+
           return unless instance.is_a?(Hash)
 
           schema["required"].reduce(JSONSchema.empty_result) do |memo, required_key|

--- a/lib/ucfg/json_schema/type.rb
+++ b/lib/ucfg/json_schema/type.rb
@@ -9,8 +9,12 @@ module Ucfg
         def validate(instance, schema, path:)
           return unless schema.key?("type")
 
-          return if schema["type"].is_a?(String) && schema["type"] == value_type(instance)
-          return if schema["type"].is_a?(Array) && schema["type"].include?(value_type(instance))
+          type = schema["type"]
+          unless valid_type_definition?(type)
+            return JSONSchema.schema_error(path, "type", "must be a supported JSON Schema type or an array of supported types")
+          end
+
+          return if Array(type).any? { |expected_type| matches_type?(instance, expected_type) }
 
           JSONSchema.result_with_validation_error("Property `#{path.join('.')}` must be of type #{type_to_sentence(schema['type'])} (#{value_type_error(instance)})")
         end
@@ -20,6 +24,31 @@ module Ucfg
             "`#{type}`"
           elsif type.is_a?(Array)
             type.map { |t| "`#{t}`" }.join(" or ")
+          end
+        end
+
+        def valid_type_definition?(type)
+          if type.is_a?(String)
+            valid_type?(type)
+          elsif type.is_a?(Array)
+            !type.empty? && type.all? { |item| item.is_a?(String) && valid_type?(item) }
+          else
+            false
+          end
+        end
+
+        def valid_type?(type)
+          %w[string boolean number integer null array object].include?(type)
+        end
+
+        def matches_type?(value, type)
+          case type
+          when "number"
+            value.is_a?(Numeric)
+          when "integer"
+            value.is_a?(Integer)
+          else
+            value_type(value) == type
           end
         end
 
@@ -39,6 +68,8 @@ module Ucfg
             "boolean"
           when nil
             "null"
+          when Integer
+            "integer"
           when Numeric
             "number"
           when Array

--- a/lib/ucfg/json_schema/unique_items.rb
+++ b/lib/ucfg/json_schema/unique_items.rb
@@ -7,6 +7,12 @@ module Ucfg
     class UniqueItems
       class << self
         def validate(instance, schema, path:)
+          return unless schema.key?("uniqueItems")
+
+          unless [true, false].include?(schema["uniqueItems"])
+            return JSONSchema.schema_error(path, "uniqueItems", "must be a boolean")
+          end
+
           return unless schema["uniqueItems"] == true
           return unless instance.is_a?(Array)
           return if instance.length == instance.uniq.length

--- a/lib/ucfg/validation_result.rb
+++ b/lib/ucfg/validation_result.rb
@@ -4,11 +4,10 @@ module Ucfg
   class ValidationResult
     class << self
       def from_json_schema_validation(result)
-        if result.nil?
-          new
-        else
-          new(validation_errors: result.fetch(:validation_errors))
-        end
+        return new if result.nil?
+        return result if result.is_a?(self)
+
+        new(validation_errors: result.fetch(:validation_errors))
       end
     end
 
@@ -21,7 +20,7 @@ module Ucfg
     alias errors validation_errors
 
     def valid?
-      validation_errors.count == 0
+      validation_errors.empty?
     end
 
     def merge!(other)

--- a/spec/json_schema/composition_spec.rb
+++ b/spec/json_schema/composition_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "JSON Schema composition keywords" do
       expect(result.errors).to eq(["Property `value` must match at least one schema in `anyOf`"])
     end
 
-    it "ignores non-object subschemas" do
+    it "rejects non-object subschemas" do
       schema = {
         "properties" => {
           "value" => {
@@ -53,7 +53,14 @@ RSpec.describe "JSON Schema composition keywords" do
         },
       }
 
-      expect(Ucfg.validate({ "value" => "text" }, schema)).to be_valid
+      result = Ucfg.validate({ "value" => "text" }, schema)
+
+      expect(result.errors).to eq(
+        [
+          "Schema keyword `value.anyOf.0` must be an object",
+          "Schema keyword `value.anyOf.1` must be an object",
+        ],
+      )
     end
   end
 
@@ -112,7 +119,7 @@ RSpec.describe "JSON Schema composition keywords" do
       expect(result.errors).to eq(["Property `value` must match exactly one schema in `oneOf` (matched 2)"])
     end
 
-    it "ignores non-object subschemas" do
+    it "rejects non-object subschemas" do
       schema = {
         "properties" => {
           "value" => {
@@ -125,7 +132,14 @@ RSpec.describe "JSON Schema composition keywords" do
         },
       }
 
-      expect(Ucfg.validate({ "value" => 7 }, schema)).to be_valid
+      result = Ucfg.validate({ "value" => 7 }, schema)
+
+      expect(result.errors).to eq(
+        [
+          "Schema keyword `value.oneOf.0` must be an object",
+          "Schema keyword `value.oneOf.1` must be an object",
+        ],
+      )
     end
   end
 
@@ -167,7 +181,7 @@ RSpec.describe "JSON Schema composition keywords" do
       expect(result.errors).to eq(["Property `value` must be greater than or equal to 3 (provided 2)"])
     end
 
-    it "ignores non-object subschemas" do
+    it "rejects non-object subschemas" do
       schema = {
         "properties" => {
           "value" => {
@@ -181,7 +195,14 @@ RSpec.describe "JSON Schema composition keywords" do
         },
       }
 
-      expect(Ucfg.validate({ "value" => 2 }, schema)).to be_valid
+      result = Ucfg.validate({ "value" => 2 }, schema)
+
+      expect(result.errors).to eq(
+        [
+          "Schema keyword `value.allOf.0` must be an object",
+          "Schema keyword `value.allOf.1` must be an object",
+        ],
+      )
     end
   end
 

--- a/spec/json_schema/items_spec.rb
+++ b/spec/json_schema/items_spec.rb
@@ -5,8 +5,8 @@ require "ucfg/json_schema"
 
 RSpec.describe "items" do
   it "supports items with schema" do
-    expect(Ucfg::JSONSchema.validate_recursively([1, 2, 3, 4, 5], { "items" => { "type" => "number" } }, path: ["key"])).to eq(:validation_errors => [])
-    expect(Ucfg::JSONSchema.validate_recursively([1, 2, "3", 4, 5], { "items" => { "type" => "number" } }, path: ["key"])).to eq(:validation_errors => ["Property `key.2` must be of type `number` (provided value `3` of type `string`)"])
-    expect(Ucfg::JSONSchema.validate_recursively([], { "items" => { "type" => "number" } }, path: ["key"])).to eq(:validation_errors => [])
+    expect(Ucfg::JSONSchema.validate_recursively([1, 2, 3, 4, 5], { "items" => { "type" => "number" } }, path: ["key"])).to be_valid
+    expect(Ucfg::JSONSchema.validate_recursively([1, 2, "3", 4, 5], { "items" => { "type" => "number" } }, path: ["key"]).errors).to eq(["Property `key.2` must be of type `number` (provided value `3` of type `string`)"])
+    expect(Ucfg::JSONSchema.validate_recursively([], { "items" => { "type" => "number" } }, path: ["key"])).to be_valid
   end
 end

--- a/spec/json_schema/pattern_properties_spec.rb
+++ b/spec/json_schema/pattern_properties_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "patternProperties" do
     expect(result.errors).to eq(["Pattern `patternProperties.[` is not a valid regular expression"])
   end
 
-  it "does not crash additionalProperties matching when pattern regex is invalid" do
+  it "reports invalid patternProperties regex without classifying additional properties" do
     config = <<-JSON
     {
       "other": "nope"
@@ -171,7 +171,6 @@ RSpec.describe "patternProperties" do
     expect(result.valid?).to eq(false)
     expect(result.errors).to eq(
       [
-        "Property `other` is not supported",
         "Pattern `patternProperties.[` is not a valid regular expression",
       ],
     )

--- a/spec/json_schema/schema_shape_spec.rb
+++ b/spec/json_schema/schema_shape_spec.rb
@@ -44,4 +44,16 @@ RSpec.describe "JSON Schema shape validation" do
       ],
     )
   end
+
+  it "reports malformed patternProperties subschemas at the pattern path" do
+    schema = {
+      "patternProperties" => {
+        "^x-" => nil,
+      },
+    }
+
+    result = Ucfg.validate({}, schema)
+
+    expect(result.errors).to eq(["Schema keyword `patternProperties.^x-` must be an object"])
+  end
 end

--- a/spec/json_schema/schema_shape_spec.rb
+++ b/spec/json_schema/schema_shape_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe "JSON Schema shape validation" do
+  it "reports malformed root keyword shapes" do
+    schema = {
+      "required" => "name",
+      "properties" => [],
+    }
+
+    result = Ucfg.validate({}, schema)
+
+    expect(result.errors).to eq(
+      [
+        "Schema keyword `required` must be an array of property names",
+        "Schema keyword `properties` must be an object",
+      ],
+    )
+  end
+
+  it "reports malformed property subschemas even when the property is absent" do
+    schema = {
+      "properties" => {
+        "service" => nil,
+      },
+    }
+
+    result = Ucfg.validate({}, schema)
+
+    expect(result.errors).to eq(["Schema keyword `properties.service` must be an object"])
+  end
+
+  it "reports malformed items and additionalProperties schemas" do
+    schema = {
+      "additionalProperties" => "no",
+      "items" => [],
+    }
+
+    result = Ucfg.validate([], schema)
+
+    expect(result.errors).to eq(
+      [
+        "Schema keyword `additionalProperties` must be a boolean or object",
+        "Schema keyword `items` must be an object",
+      ],
+    )
+  end
+end

--- a/spec/nested_validation_spec.rb
+++ b/spec/nested_validation_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Nested validation" do
     result = Ucfg.validate(JSON.parse(config), JSON.parse(schema))
 
     expect(result.valid?).to eq(false)
-    expect(result.errors).to eq(["Property `devotus.value` must be of type `string` (provided value `1` of type `number`)"])
+    expect(result.errors).to eq(["Property `devotus.value` must be of type `string` (provided value `1` of type `integer`)"])
   end
 
   it "fails if with multiple errors" do

--- a/spec/numeric_validation_spec.rb
+++ b/spec/numeric_validation_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Numeric validation" do
     )
   end
 
-  it "does not skip min when max is non-numeric" do
+  it "reports invalid max schema values without skipping valid min checks" do
     schema = <<-JSON
     {
       "properties": {
@@ -204,10 +204,15 @@ RSpec.describe "Numeric validation" do
     JSON
     schema_as_hash = JSON.parse(schema)
 
-    expect(Ucfg.validate({ "a" => 2 }, schema_as_hash).errors).to eq(["Property `a` must be greater than or equal to 3 (provided 2)"])
+    expect(Ucfg.validate({ "a" => 2 }, schema_as_hash).errors).to eq(
+      [
+        "Schema keyword `a.max` must be a number",
+        "Property `a` must be greater than or equal to 3 (provided 2)",
+      ],
+    )
   end
 
-  it "does not skip max when min is non-numeric" do
+  it "reports invalid min schema values without skipping valid max checks" do
     schema = <<-JSON
     {
       "properties": {
@@ -220,7 +225,12 @@ RSpec.describe "Numeric validation" do
     JSON
     schema_as_hash = JSON.parse(schema)
 
-    expect(Ucfg.validate({ "a" => 4 }, schema_as_hash).errors).to eq(["Property `a` must be less than or equal to 3 (provided 4)"])
+    expect(Ucfg.validate({ "a" => 4 }, schema_as_hash).errors).to eq(
+      [
+        "Property `a` must be less than or equal to 3 (provided 4)",
+        "Schema keyword `a.min` must be a number",
+      ],
+    )
   end
 
   it "ignores minimum and maximum when instance is not numeric" do
@@ -239,7 +249,7 @@ RSpec.describe "Numeric validation" do
     expect(Ucfg.validate({ "a" => "text" }, schema_as_hash)).to be_valid
   end
 
-  it "ignores invalid minimum and maximum schema values" do
+  it "reports invalid minimum and maximum schema values" do
     schema = <<-JSON
     {
       "properties": {
@@ -252,6 +262,11 @@ RSpec.describe "Numeric validation" do
     JSON
     schema_as_hash = JSON.parse(schema)
 
-    expect(Ucfg.validate({ "a" => 99 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "a" => 99 }, schema_as_hash).errors).to eq(
+      [
+        "Schema keyword `a.maximum` must be a number",
+        "Schema keyword `a.minimum` must be a number",
+      ],
+    )
   end
 end

--- a/spec/type_validation_spec.rb
+++ b/spec/type_validation_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Type validation" do
         "key_string": { "type": "string" },
         "key_boolean": { "type": "boolean" },
         "key_number": { "type": "number" },
+        "key_integer": { "type": "integer" },
         "key_null": { "type": "null" },
         "key_object": { "type": "object" },
         "key_array": { "type": "array" },
@@ -41,11 +42,13 @@ RSpec.describe "Type validation" do
     expect(Ucfg.validate({ "key_number" => false }, schema_as_hash)).to_not be_valid
     expect(Ucfg.validate({ "key_number" => nil }, schema_as_hash)).to_not be_valid
     expect(Ucfg.validate({ "key_number" => 123 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "key_integer" => 123 }, schema_as_hash)).to be_valid
+    expect(Ucfg.validate({ "key_integer" => 1.5 }, schema_as_hash).errors).to eq(["Property `key_integer` must be of type `integer` (provided value `1.5` of type `number`)"])
     expect(Ucfg.validate({ "key_null" => false }, schema_as_hash)).to_not be_valid
     expect(Ucfg.validate({ "key_null" => nil }, schema_as_hash)).to be_valid
     expect(Ucfg.validate({ "key_object" => {} }, schema_as_hash)).to be_valid
     expect(Ucfg.validate({ "key_array" => ["hey"] }, schema_as_hash)).to be_valid
     expect(Ucfg.validate({ "key_array" => {} }, schema_as_hash)).to_not be_valid
-    expect(Ucfg.validate({ "key_invalid_type" => "value" }, schema_as_hash)).to_not be_valid
+    expect(Ucfg.validate({ "key_invalid_type" => "value" }, schema_as_hash).errors).to eq(["Schema keyword `key_invalid_type.type` must be a supported JSON Schema type or an array of supported types"])
   end
 end

--- a/spec/ucfg_spec.rb
+++ b/spec/ucfg_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Ucfg do
 
   describe ".load_files" do
     it "merges two files from left to right" do
-      allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({ "a" => 1 })
-      allow(described_class).to receive(:load_file).with("override.yml", erb: false).and_return({ "b" => 2 })
+      allow(described_class).to receive(:load_file).with("base.yml", erb: false, env: false).and_return({ "a" => 1 })
+      allow(described_class).to receive(:load_file).with("override.yml", erb: false, env: false).and_return({ "b" => 2 })
 
       merger = double("Ucfg::ConfigMerger")
       stub_const("Ucfg::ConfigMerger", merger)
@@ -24,9 +24,9 @@ RSpec.describe Ucfg do
     end
 
     it "applies three-file precedence with later files overriding earlier ones" do
-      allow(described_class).to receive(:load_file).with("one.yml", erb: false).and_return({ "timeout" => 10 })
-      allow(described_class).to receive(:load_file).with("two.yml", erb: false).and_return({ "timeout" => 20 })
-      allow(described_class).to receive(:load_file).with("three.yml", erb: false).and_return({ "timeout" => 30 })
+      allow(described_class).to receive(:load_file).with("one.yml", erb: false, env: false).and_return({ "timeout" => 10 })
+      allow(described_class).to receive(:load_file).with("two.yml", erb: false, env: false).and_return({ "timeout" => 20 })
+      allow(described_class).to receive(:load_file).with("three.yml", erb: false, env: false).and_return({ "timeout" => 30 })
 
       merger = double("Ucfg::ConfigMerger")
       stub_const("Ucfg::ConfigMerger", merger)
@@ -41,10 +41,10 @@ RSpec.describe Ucfg do
     end
 
     it "delegates nested hash cases to ConfigMerger and returns its result" do
-      allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({
+      allow(described_class).to receive(:load_file).with("base.yml", erb: false, env: false).and_return({
                                                                                     "service" => { "host" => "localhost", "port" => 8080 }
                                                                                   })
-      allow(described_class).to receive(:load_file).with("override.yml", erb: false).and_return({
+      allow(described_class).to receive(:load_file).with("override.yml", erb: false, env: false).and_return({
                                                                                         "service" => { "port" => 9090 }
                                                                                       })
 
@@ -67,8 +67,8 @@ RSpec.describe Ucfg do
     end
 
     it "delegates array cases to ConfigMerger and returns its result" do
-      allow(described_class).to receive(:load_file).with("base.yml", erb: false).and_return({ "hosts" => ["a", "b"] })
-      allow(described_class).to receive(:load_file).with("override.yml", erb: false).and_return({ "hosts" => ["c"] })
+      allow(described_class).to receive(:load_file).with("base.yml", erb: false, env: false).and_return({ "hosts" => ["a", "b"] })
+      allow(described_class).to receive(:load_file).with("override.yml", erb: false, env: false).and_return({ "hosts" => ["c"] })
 
       merger = double("Ucfg::ConfigMerger")
       stub_const("Ucfg::ConfigMerger", merger)


### PR DESCRIPTION
This tightens JSON Schema validation so malformed schemas are surfaced explicitly instead of being silently ignored, and makes the recursive validation pipeline easier to reason about.

## Summary
- Use `ValidationResult` throughout recursive validation and move validator ordering into a frozen registry.
- Validate schema keyword shapes for composition, properties, items, required, enum, numeric, string, array, and type validators.
- Coordinate `patternProperties` with `additionalProperties` so invalid patterns are reported without also misclassifying keys.
- Add JSON Schema `integer` type support and focused schema-shape coverage.

## Testing
- `bundle exec rake spec`